### PR TITLE
Фикс зума с вайдскрином

### DIFF
--- a/code/datums/view.dm
+++ b/code/datums/view.dm
@@ -56,6 +56,12 @@
 /datum/view_data/proc/add(num_to_add)
 	width += num_to_add
 	height += num_to_add
+
+	if(chief.prefs.widescreenpref) // if widescreen enabled
+	{
+		var/list/wide_size = getviewsize(default) // pickup current resolution
+		width = round(width * (wide_size[1] / wide_size[2])) // trying to save aspect ratio, cant be float/double number
+	}
 	apply()
 
 ///adds the size, which can also be a string, to the default and applies it
@@ -63,6 +69,12 @@
 	var/list/new_size = getviewsize(toAdd)
 	width += new_size[1]
 	height += new_size[2]
+
+	if(chief.prefs.widescreenpref) // if widescreen enabled
+	{
+		var/list/wide_size = getviewsize(default) // pickup current resolution
+		width = round(width * (wide_size[1] / wide_size[2])) // trying to save aspect ratio, cant be float/double number
+	}
 	apply()
 
 ///INCREASES the view radius by this.
@@ -70,6 +82,12 @@
 	var/list/new_size = getviewsize(toAdd)  //Backward compatability to account
 	width = new_size[1] //for a change in how sizes get calculated. we used to include world.view in
 	height = new_size[2] //this, but it was jank, so I had to move it
+
+	if(chief.prefs.widescreenpref) // if widescreen enabled
+	{
+		var/list/wide_size = getviewsize(default) // pickup current resolution
+		width = round(width * (wide_size[1] / wide_size[2])) // trying to save aspect ratio, cant be float/double number
+	}
 	apply()
 
 ///sets width and height as numbers

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -73,8 +73,8 @@ GLOBAL_DATUM_INIT(welding_sparks_prepdoor, /mutable_appearance, mutable_appearan
 	var/zoom = FALSE
 	///how much tiles the zoom offsets to the direction it zooms to.
 	var/zoom_tile_offset = 6
-	///how much tiles the zoom zooms out, 7 is the default view.
-	var/zoom_viewsize = 7
+	///how much tiles the zoom zooms out, 5 is the default view.
+	var/zoom_viewsize = 5
 	///if you can move with the zoom on, only works if zoom_view_size is 7 otherwise CRASH() is called due to maptick performance reasons.
 	var/zoom_allow_movement = FALSE
 

--- a/code/game/objects/items/binoculars.dm
+++ b/code/game/objects/items/binoculars.dm
@@ -11,7 +11,7 @@
 	throw_range = 15
 	throw_speed = 3
 	zoom_tile_offset = 11
-	zoom_viewsize = 12
+	zoom_viewsize = 15
 
 
 /obj/item/binoculars/attack_self(mob/user)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -502,7 +502,7 @@
 	active = FALSE
 	flags_item = DOES_NOT_NEED_HANDS
 	zoom_tile_offset = 11
-	zoom_viewsize = 12
+	zoom_viewsize = 15
 	flags_attach_features = ATTACH_REMOVABLE|ATTACH_ACTIVATION|ATTACH_APPLY_ON_MOB
 	slot = ATTACHMENT_SLOT_HEAD_MODULE
 	prefered_slot = SLOT_HEAD

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -719,7 +719,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	if(client.view != CONFIG_GET(string/default_view))
 		client.view_size.reset_to_default()
 	else
-		client.view_size.set_view_radius_to(12.5)
+		client.view_size.set_view_radius_to(12)
 
 
 /mob/dead/observer/verb/add_view_range(input as num)

--- a/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/boiler/abilities_boiler.dm
@@ -45,7 +45,7 @@ GLOBAL_LIST_INIT(boiler_glob_image_list, list(
 			span_notice("We start focusing your sight to look off into the distance."), null, 5)
 		if(!do_after(X, 1 SECONDS, FALSE, null, BUSY_ICON_GENERIC) || X.is_zoomed)
 			return
-		X.zoom_in(11)
+		X.zoom_in(4.5)
 		..()
 
 // ***************************************

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/abilities_queen.dm
@@ -246,7 +246,7 @@
 	if(message)
 		xeno.visible_message(span_notice("[xeno] emits a broad and weak psychic aura."),
 		span_notice("We start focusing our psychic energy to expand the reach of our senses."), null, 5)
-	xeno.zoom_in(0, 12)
+	xeno.zoom_in(0, 4.5)
 
 
 /datum/action/xeno_action/toggle_queen_zoom/proc/zoom_xeno_out(message = TRUE)

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -311,7 +311,7 @@
 	update_sight()
 
 
-/mob/living/carbon/xenomorph/proc/zoom_in(tileoffset = 5, viewsize = 12)
+/mob/living/carbon/xenomorph/proc/zoom_in(tileoffset = 5, viewsize = 4.5)
 	if(stat || resting)
 		if(is_zoomed)
 			is_zoomed = 0
@@ -324,7 +324,7 @@
 		return
 	zoom_turf = get_turf(src)
 	is_zoomed = 1
-	client.view_size.set_view_radius_to(viewsize/2-2) //convert diameter to radius
+	client.view_size.set_view_radius_to(viewsize) //convert diameter to radius
 	var/viewoffset = 32 * tileoffset
 	switch(dir)
 		if(NORTH)

--- a/code/modules/projectiles/gun_attachables.dm
+++ b/code/modules/projectiles/gun_attachables.dm
@@ -690,7 +690,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	aim_speed_mod = 0.3
 	wield_delay_mod = 0.2 SECONDS
 	zoom_tile_offset = 7
-	zoom_viewsize = 2
+	zoom_viewsize = 5
 	add_aim_mode = TRUE
 
 /obj/item/attachable/scope/mosin
@@ -749,7 +749,7 @@ inaccurate. Don't worry if force is ever negative, it won't runtime.
 	flags_attach_features = ATTACH_ACTIVATION
 	scope_delay = 2 SECONDS
 	zoom_tile_offset = 7
-	zoom_viewsize = 2
+	zoom_viewsize = 5
 	deployed_scope_rezoom = FALSE
 
 /obj/item/attachable/scope/activate(mob/living/carbon/user, turn_off)

--- a/code/modules/projectiles/guns/specialist.dm
+++ b/code/modules/projectiles/guns/specialist.dm
@@ -155,7 +155,7 @@ Note that this means that snipers will have a slowdown of 3, due to the scope
 		to_chat(user, span_danger("You lose sight of your target!"))
 		playsound(user,'sound/machines/click.ogg', 25, 1)
 
-/obj/item/weapon/gun/rifle/sniper/antimaterial/zoom(mob/living/user, tileoffset = 11, viewsize = 12) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 7 is normal view
+/obj/item/weapon/gun/rifle/sniper/antimaterial/zoom(mob/living/user, tileoffset = 11, viewsize = 10) //tileoffset is client view offset in the direction the user is facing. viewsize is how far out this thing zooms. 5 is normal view
 	. = ..()
 	var/obj/item/attachable/scope = LAZYACCESS(attachments_by_slot, ATTACHMENT_SLOT_RAIL)
 	if(!scope.zoom && (targetmarker_on || targetmarker_primed) )

--- a/config/config.txt
+++ b/config/config.txt
@@ -195,7 +195,7 @@ IS_AUTOMATIC_BALANCE_ON
 ##  15x15 would be the standard square view. 21x15 is what goonstation uses for widescreen.
 ##  Setting this to something different from DEFAULT_VIEW_SQUARE will enable widescreen toggles
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
-DEFAULT_VIEW 19x15
+DEFAULT_VIEW 21x15
 
 ##Default view size, in tiles. Should *always* be square.
 ## The alternative square viewport size if you're using a widescreen view size


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Исправлен пролаг при использовании прицелов, биноклей и т.д. с включенным Widescreen. Widescreen теперь 21х15 из-за соотношений сторон 1,4:1. При старом 19х15 (1,26:1) невозможно без изменений окна увеличивать/уменьшать обзор.
Из-за того что соотношение сторон теперь 1,4:1 увеличивать обзор стоит на числа кратные 5 для того чтобы не изменять окно в Widescreen. Квадратный режим работает так же без изменений.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Зум можно нормально использовать не только в дефолтном окне.
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: При изменении размера окна происходит попытка сохранить соотношение сторон
code: Дефолтный зум 7>5
code: Зум биноклей 12>15
code: Зум госта 26>25
code: Зум квины 9>10
code: Зум бойлера 8>10
code: Убрал ненужные вычисления при зуме ксеноморфов
code: Зум дефолтного прицела 2>5
code: Зум оптики 12>10
config: Widescreen теперь 21х15
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
