### PR TITLE
Crusher stomp fix

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/abilities_crusher.dm
@@ -34,7 +34,7 @@
 		if(distance == 0) //If we're on top of our victim, give him the full impact
 			GLOB.round_statistics.crusher_stomp_victims++
 			SSblackbox.record_feedback("tally", "round_statistics", 1, "crusher_stomp_victims")
-			M.take_overall_damage(damage, BRUTE, MELEE, updating_health = TRUE)
+			M.take_overall_damage(damage, BRUTE, MELEE, updating_health = TRUE, penetration = 100)
 			M.Paralyze(3 SECONDS)
 			to_chat(M, span_highdanger("You are stomped on by [X]!"))
 			shake_camera(M, 3, 3)


### PR DESCRIPTION
## About The Pull Request

Дал способности крашера "Stomp" 100 пробивания 

https://user-images.githubusercontent.com/99790528/212540035-7117aa3b-ec18-4a9c-895e-cb5292c2b9e8.mp4


## Why It's Good For The Game

Способность крашера "Stomp" имеет особенность, а именно, если стоять на цели - она нанесёт в два раза больше урона
Но к сожалению из за особенности её кода(нанесение малого количества урона но всему телу), броня полностью убирала двойной урон по цели, что полностью лишает смысла эту часть способности.
Теперь нет.

:cl:
fix: Не рабочая часть способности "Stomp" теперь работает.
/:cl:
