### PR TITLE
Hunter apha stealth increase 

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -550,14 +550,14 @@ GLOBAL_LIST_INIT(xenoupgradetiers, list(XENO_UPGRADE_BASETYPE, XENO_UPGRADE_INVA
 
 //Hunter Defines
 #define HUNTER_STEALTH_COOLDOWN 50 //5 seconds
-#define HUNTER_STEALTH_WALK_PLASMADRAIN 2
-#define HUNTER_STEALTH_RUN_PLASMADRAIN 5
-#define HUNTER_STEALTH_STILL_ALPHA 25 //90% transparency
+#define HUNTER_STEALTH_WALK_PLASMADRAIN 1
+#define HUNTER_STEALTH_RUN_PLASMADRAIN 2
+#define HUNTER_STEALTH_ALPHA 0 //100% transparency
 #define HUNTER_STEALTH_WALK_ALPHA 38 //85% transparency
 #define HUNTER_STEALTH_RUN_ALPHA 128 //50% transparency
 #define HUNTER_STEALTH_STEALTH_DELAY 30 //3 seconds before 95% stealth
 #define HUNTER_STEALTH_INITIAL_DELAY 20 //2 seconds before we can increase stealth
-#define HUNTER_POUNCE_SNEAKATTACK_DELAY 30 //3 seconds before we can sneak attack
+#define HUNTER_POUNCE_SNEAKATTACK_DELAY 20 //2 seconds before we can sneak attack
 #define HANDLE_STEALTH_CHECK 1
 #define HANDLE_SNEAK_ATTACK_CHECK 3
 #define HUNTER_SNEAK_SLASH_ARMOR_PEN 20 //1 - this value = the actual penetration

--- a/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/hunter/abilities_hunter.dm
@@ -122,15 +122,15 @@
 		return
 	//Stationary stealth
 	else if(owner.last_move_intent < world.time - HUNTER_STEALTH_STEALTH_DELAY) //If we're standing still for 4 seconds we become almost completely invisible
-		owner.alpha = HUNTER_STEALTH_STILL_ALPHA * stealth_alpha_multiplier
+		owner.alpha = HUNTER_STEALTH_ALPHA * stealth_alpha_multiplier
 	//Walking stealth
 	else if(owner.m_intent == MOVE_INTENT_WALK)
 		xenoowner.use_plasma(HUNTER_STEALTH_WALK_PLASMADRAIN)
-		owner.alpha = HUNTER_STEALTH_WALK_ALPHA * stealth_alpha_multiplier
+		owner.alpha = HUNTER_STEALTH_ALPHA * stealth_alpha_multiplier
 	//Running stealth
 	else
 		xenoowner.use_plasma(HUNTER_STEALTH_RUN_PLASMADRAIN)
-		owner.alpha = HUNTER_STEALTH_RUN_ALPHA * stealth_alpha_multiplier
+		owner.alpha = HUNTER_STEALTH_ALPHA * stealth_alpha_multiplier
 	//If we have 0 plasma after expending stealth's upkeep plasma, end stealth.
 	if(!xenoowner.plasma_stored)
 		to_chat(xenoowner, span_xenodanger("We lack sufficient plasma to remain camouflaged."))


### PR DESCRIPTION
## About The Pull Request

Теперь хантер, после некоторого времени активации способности, становится полностью невидимым.
трата плазмы в невидимости уменьшена
при ходьбе - до 1
при беге - до 2
Время до возможности сделать скрытую атаку, уменьшено с 3 до 2. (всё ещё есть 5 секунд кд у невидимости, т.е время между этими ударами суммарно 7 секунд)

## Why It's Good For The Game

Дыра в линейки Руня -> Хантер-> Рава. Будет частично закрыта. Теперь не будет ощущения что ты просто ждёшь эво очки и слот, пока растёшь на хантере.

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Воровство предметов прямо на глазах у маров.
add: Толкание маров в застройку из невидимости. (хантера всё ещё видно через шифт+пкм, и слышно на сенсорах)
del: Полная бесполезность невидимости / хантера без примо.
:cl: