### PR TITLE
Тот же фильтр у равы, чистая история комитов. Удар.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/ravager/abilities_ravager.dm
@@ -351,6 +351,7 @@
 		var/datum/action/xeno_action/charge = X.actions_by_path[/datum/action/xeno_action/activable/charge]
 		var/datum/action/xeno_action/ravage = X.actions_by_path[/datum/action/xeno_action/activable/ravage]
 		var/datum/action/xeno_action/endure/endure_ability = X.actions_by_path[/datum/action/xeno_action/endure]
+		X.overlay_fullscreen("xeno_feast", /atom/movable/screen/fullscreen/bloodlust)
 
 		if(endure_ability.endure_duration) //Check if Endure is active
 			endure_ability.endure_threshold = RAVAGER_ENDURE_HP_LIMIT * (1 + rage_power) //Endure crit threshold scales with Rage Power; min -100, max -150
@@ -365,7 +366,7 @@
 		affected_tiles.Shake(4, 4, 1 SECONDS) //SFX
 
 	for(var/mob/living/L AS in GLOB.mob_living_list) //Roar that applies cool SFX
-		if(L.stat == DEAD || !L.hud_used || (get_dist(L, X) > rage_power_radius)) //We don't care about the dead
+		if(L.stat == DEAD || !L.hud_used || (get_dist(L, X) > rage_power_radius || X)) //We don't care about the dead
 			continue
 
 		shake_camera(L, 1 SECONDS, 1)
@@ -449,6 +450,7 @@
 	X.do_jitter_animation(1000)
 
 	X.remove_filter("ravager_rage_outline")
+	X.clear_fullscreen ("xeno_feast")
 	X.visible_message(span_warning("[X] seems to calm down."), \
 	span_highdanger("Our rage subsides and its power leaves our body, leaving us exhausted."))
 


### PR DESCRIPTION
## About The Pull Request

Удаление эффектов тряски и помутнения для самого Равы при нажатии ярости (другие ксено или мары всё ещё будут их получать)
При супер рейдже, Рава получает фильтр 'жажды крови' который до этого был только у Горгера (вроде бы)
![image](https://user-images.githubusercontent.com/99790528/212867801-681c1432-b088-410f-be57-7879bbb12ddc.png)

## Why It's Good For The Game

Улучшение 'качества жизни'
Это просто удобно и приятно
Логично что эффект 'ааа, он так громко крикнул' должны получать морпехи или хотя бы другие ксеноморфы, но никак не сам тот кто 'громко крикнул'
Теперь рава в самый важный момент нажатия супер ярости/ярости не будет теряться как слёпой котёнок из за трясущегося экрана, а впиваться в плоть морпехам, получая отхил.

:cl:
add: Красоту.
add: Кайф.
del: Многие скил ишуй моменты с равами.
:cl:

