### PR TITLE
Фикс чата

### DIFF
--- a/code/datums/keybinding/communication.dm
+++ b/code/datums/keybinding/communication.dm
@@ -7,11 +7,25 @@
 	full_name = "IC Say"
 	keybind_signal = COMSIG_KB_CLIENT_SAY_DOWN
 
+/datum/keybinding/client/communication/say/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(SAY_CHANNEL)]")
+	return TRUE
+
 /datum/keybinding/client/communication/radio
 	hotkey_keys = list("Y")
 	name = RADIO_CHANNEL
 	full_name = "IC Radio (;)"
 	keybind_signal = COMSIG_KB_CLIENT_RADIO_DOWN
+
+/datum/keybinding/client/communication/radio/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(RADIO_CHANNEL)]")
+	return TRUE
 
 /datum/keybinding/client/communication/ooc
 	hotkey_keys = list("O")
@@ -19,24 +33,58 @@
 	full_name = "Out Of Character Say (OOC)"
 	keybind_signal = COMSIG_KB_CLIENT_OOC_DOWN
 
+/datum/keybinding/client/communication/ooc/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(OOC_CHANNEL)]")
+	return TRUE
+
 /datum/keybinding/client/communication/me
 	hotkey_keys = list("M")
 	name = ME_CHANNEL
 	full_name = "Custom Emote (/Me)"
 	keybind_signal = COMSIG_KB_CLIENT_ME_DOWN
 
+/datum/keybinding/client/communication/me/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(ME_CHANNEL)]")
+	return TRUE
+
 /datum/keybinding/client/communication/xooc
 	name = XOOC_CHANNEL
 	full_name = "Xeno OOC(XOOC)"
 	keybind_signal = COMSIG_KB_CLIENT_XOOC_DOWN
+
+/datum/keybinding/client/communication/xooc/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(XOOC_CHANNEL)]")
+	return TRUE
 
 /datum/keybinding/client/communication/mooc
 	name = MOOC_CHANNEL
 	full_name = "Marine OOC(MOOC)"
 	keybind_signal = COMSIG_KB_CLIENT_MOOC_DOWN
 
+/datum/keybinding/client/communication/mooc/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(MOOC_CHANNEL)]")
+	return TRUE
+
 /datum/keybinding/client/communication/looc
 	name = LOOC_CHANNEL
 	full_name = "Local OOC(LOOC)"
 	keybind_signal = COMSIG_KB_CLIENT_LOOC_DOWN
 
+/datum/keybinding/client/communication/looc/down(client/user)
+	. = ..()
+	if(.)
+		return
+	winset(user, null, "command=[user.tgui_say_create_open_command(LOOC_CHANNEL)]")
+	return TRUE

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -811,28 +811,6 @@
 					movement_keys[key] = WEST
 				if("South")
 					movement_keys[key] = SOUTH
-				if(SAY_CHANNEL)
-					var/say = tgui_say_create_open_command(SAY_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[say]")
-				if(RADIO_CHANNEL)
-					var/radio = tgui_say_create_open_command(RADIO_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[radio]")
-				if(ME_CHANNEL)
-					var/me = tgui_say_create_open_command(ME_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[me]")
-				if(OOC_CHANNEL)
-					var/ooc = tgui_say_create_open_command(OOC_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[ooc]")
-				if(LOOC_CHANNEL)
-					var/looc = tgui_say_create_open_command(LOOC_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[looc]")
-				if(MOOC_CHANNEL)
-					var/mooc = tgui_say_create_open_command(MOOC_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[mooc]")
-				if(XOOC_CHANNEL)
-					var/xooc = tgui_say_create_open_command(XOOC_CHANNEL)
-					winset(src, "default-[REF(key)]", "parent=default;name=[key];command=[xooc]")
-
 
 /client/proc/change_view(new_size)
 	if(isnull(new_size))


### PR DESCRIPTION

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Теперь окно чата появляется независимо от раскладки
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Не надо дрочить раскладку. Больше не будет случаев когда нужно срочно что то написать, но из за раскладки это не получалось
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: /datum/keybinding/client/communication/down(client/user) для всех видов чатов
del: В /client/proc/update_special_keybinds(datum/preferences/direct_prefs) все привязки для чата
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
