### PR TITLE
Прозрачность щита, при маленьком остатке прочности.

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -210,9 +210,10 @@
 		alpha = 192 // ~ 3/4 visibility
 	if(obj_integrity <= 175)
 		alpha = 128 // ~ 2/4 visibility
-	if(obj_integrity <= 100)
+	if(obj_integrity <= 126 && obj_integrity >= 124)
+		owner.balloon_alert(owner, "Our shield is almost broken!")
+	if(obj_integrity <= 125)
 		alpha = 64 // ~ 1/4 visibility
-		owner.balloon_alert(owner, "NOW")
 	if(obj_integrity <= 0)
 		release_projectiles()
 		owner.apply_effects(weaken = 0.5)

--- a/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warlock/abilities_warlock.dm
@@ -206,6 +206,13 @@
 	proj.iff_signal = null
 	frozen_projectiles += proj
 	take_damage(proj.damage, proj.ammo.damage_type, proj.ammo.armor_type, 0, turn(proj.dir, 180), proj.ammo.penetration)
+	if(obj_integrity <= 300)
+		alpha = 192 // ~ 3/4 visibility
+	if(obj_integrity <= 175)
+		alpha = 128 // ~ 2/4 visibility
+	if(obj_integrity <= 100)
+		alpha = 64 // ~ 1/4 visibility
+		owner.balloon_alert(owner, "NOW")
 	if(obj_integrity <= 0)
 		release_projectiles()
 		owner.apply_effects(weaken = 0.5)


### PR DESCRIPTION
## About The Pull Request

Теперь когда у щита хп меньше некого порога (300, 175, 125). Его прозрачность повышается.
Так же. на последней стадии прозрачности, для варлока всплывает сообщение "Our shield is almost broken!" (если 125 хп не снимаются за выстрел, starege)

## Why It's Good For The Game

Более очевидная работа щита, как для варлока, так и для его противников.

:cl:
add: Прозрачность игрового процесса.
:cl: