### PR TITLE
Баф крика квины.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -386,12 +386,12 @@ Contains most of the procs that are called when a mob is attacked by something
 /mob/living/carbon/human/screech_act(mob/living/carbon/xenomorph/queen/Q, screech_range = WORLD_VIEW, within_sight = TRUE)
 	var/dist_pct = get_dist(src, Q) / screech_range
 
-	// Intensity is reduced by a 80% if you can't see the queen. Hold orders will reduce by an extra 10% per rank.
-	var/reduce_within_sight = within_sight ? 1 : 0.2
+	// Intensity is reduced by a 40% if you can't see the queen. Hold orders will reduce by an extra 10% per rank.
+	var/reduce_within_sight = within_sight ? 1 : 0.6
 	var/reduce_prot_aura = protection_aura * 0.1
 
-	var/reduction = max(min(1, reduce_within_sight - reduce_prot_aura), 0.1) // Capped at 90% reduction
-	var/stun_duration = (LERP(1, 0.4, dist_pct) * reduction) * 20 //Max 1.5 beside Queen, 0.4 at the edge.
+	var/reduction = max(min(1, reduce_within_sight - reduce_prot_aura), 0.3) // Capped at 70% reduction
+	var/stun_duration = (LERP(5, 1, dist_pct) * reduction) * 20 //Max 8 beside Queen, 2 at the edge.
 
 	to_chat(src, span_danger("An ear-splitting guttural roar tears through your mind and makes your world convulse!"))
 	Stun(stun_duration)


### PR DESCRIPTION
## About The Pull Request

Максимальный стан 8, рядом с квиной. Минимальный 2, на границе крика. 
(дальность 7 клеток, длительность уменьшается на 1 с каждой клеткой)

То что мар не видит квину, во время крика, режет эффект крика не на 80 процентов, как раньше, а на 40.
Приказ на защиту, всё ещё дополнительно режет эффект крика, вплоть до 70 процентов.


## Why It's Good For The Game

Сильный эффект, с большим кд, для единственного боевого навыка главы улья.
Есть возможность "защиты" от этой способности, в виде приказа на защиту, и вставанием за преградами.

## Changelog
Длительность стана
Было:  Максимум 1,5 рядом с королевой, 0,4 на краю.
Стало: Максимум 8 рядом с королевой, 2 на краю.

Уменьшение эффекта от того что морпех моргнул (не видит королеву)
Было Интенсивность уменьшается на 80%, если вы не видите королеву.
Стало Интенсивность уменьшается на 40%, если вы не видите королеву.

Максимальное уменьшение эффекта.
Было  Ограничено уменьшением на 90%
Стало Ограничено уменьшением на 70%