### PR TITLE
Фикс псипоинтов

### DIFF
--- a/code/datums/gamemodes/distress.dm
+++ b/code/datums/gamemodes/distress.dm
@@ -33,7 +33,7 @@
 
 /datum/game_mode/infestation/distress/post_setup()
 	. = ..()
-	SSpoints.add_psy_points(XENO_HIVE_NORMAL, 2 * SILO_PRICE + 4 * XENO_TURRET_PRICE)
+	SSpoints.add_psy_points(XENO_HIVE_NORMAL, 2000)
 
 	for(var/i in GLOB.xeno_turret_turfs)
 		new /obj/structure/xeno/xeno_turret(i)


### PR DESCRIPTION
После баффа блессингов оказалось что у ксенов стало меньше псипоинтов...
Этот ПР возвращает 2000 псипоинтов.