### PR TITLE
Откат нерфа Корана

### DIFF
--- a/code/game/objects/items/storage/bible.dm
+++ b/code/game/objects/items/storage/bible.dm
@@ -14,6 +14,7 @@
 	icon = 'icons/obj/items/priest.dmi'
 	icon_state = "Koran"
 	deity_name = "Allah"
+	storage_slots = 7
 	actions_types = list(/datum/action/item_action)
 
 /obj/item/storage/bible/koran/attack_self(mob/user)

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -387,3 +387,8 @@ GLOBAL_LIST_EMPTY(gear_datums)
 	cost = 2
 	slot = SLOT_R_HAND
 
+/datum/gear/b19
+	display_name = "B19 armor"
+	path = /obj/item/clothing/mask/gas/clown_hat
+	cost = 6
+	slot = SLOT_IN_BACKPACK

--- a/code/modules/client/preferences_gear.dm
+++ b/code/modules/client/preferences_gear.dm
@@ -387,8 +387,3 @@ GLOBAL_LIST_EMPTY(gear_datums)
 	cost = 2
 	slot = SLOT_R_HAND
 
-/datum/gear/b19
-	display_name = "B19 armor"
-	path = /obj/item/clothing/mask/gas/clown_hat
-	cost = 6
-	slot = SLOT_IN_BACKPACK


### PR DESCRIPTION
## About The Pull Request

Почему-то количество слотов в Библии уменьшилось с 7 до 1, поэтому пострадал люксовый Коран из лодаутов
Возвращаю ему и только ему 7 слотов, поскольку это эксклюзивный предмет для лодаута, который так был задуман

Добавил в лодаут б19

## Why It's Bad For The Game

откат нерфа маринов

## Changelog

:cl:
add: b19 armor in gear for 6 points
fix: fix gear koran slots reduction
/:cl:
