### PR TITLE
Подствольный фонарик у плазмапистола

### DIFF
--- a/code/modules/projectiles/guns/pistols.dm
+++ b/code/modules/projectiles/guns/pistols.dm
@@ -84,6 +84,7 @@
 	attachable_allowed = list(
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/flashlight,
+		/obj/item/attachable/flashlight/under,
 		/obj/item/attachable/lasersight,
 		/obj/item/attachable/gyro,
 		/obj/item/attachable/lace,


### PR DESCRIPTION
## About The Pull Request

Подствольный фонарик у плазмапистола

## Why It's Good For The Game

На плазмач лезет обычный фонарик
На плазмач лезут подстволы
На плазмач должен лезть подствольный фонарь, но оффы забыли его добавить
Исправляем

:cl:
fix: plasma pistol cant hold under flashlight
/:cl:
