### PR TITLE
НЕРЕАЛЬНЫЙ (юбилейный сотый пр) бафф валькирии и б18

### DIFF
--- a/code/__DEFINES/objects.dm
+++ b/code/__DEFINES/objects.dm
@@ -131,10 +131,10 @@ GLOBAL_LIST_INIT(restricted_camera_networks, list( //Those networks can only be 
 #define B18_OXY_CODE 3
 #define B18_TOX_CODE 4
 #define B18_PAIN_CODE 5
-#define B18_DAMAGE_MIN 50
-#define B18_DAMAGE_MAX 150
-#define B18_PAIN_MIN 50
-#define B18_PAIN_MAX 150
+#define B18_DAMAGE_MIN 20
+#define B18_DAMAGE_MAX 300
+#define B18_PAIN_MIN 20
+#define B18_PAIN_MAX 300
 
 
 //Razor wire

--- a/code/datums/components/suit_autodoc.dm
+++ b/code/datums/components/suit_autodoc.dm
@@ -1,5 +1,5 @@
-#define SUIT_AUTODOC_DAM_MIN 50
-#define SUIT_AUTODOC_DAM_MAX 150
+#define SUIT_AUTODOC_DAM_MIN 20
+#define SUIT_AUTODOC_DAM_MAX 300
 #define COOLDOWN_CHEM_BURN "chem_burn"
 #define COOLDOWN_CHEM_OXY "oxy_chems"
 #define COOLDOWN_CHEM_BRUTE "brute_chems"
@@ -357,6 +357,7 @@
 	<A href='byond://?src=[REF(src)];analyzer=1'>Scan Wearer</A><BR>
 	<BR>
 	<B>Damage Trigger Threshold (Max [SUIT_AUTODOC_DAM_MAX], Min [SUIT_AUTODOC_DAM_MIN]):</B><BR>
+	<A href='byond://?src=[REF(src)];automed_damage=-100'>-100</A><BR>
 	<A href='byond://?src=[REF(src)];automed_damage=-50'>-50</A>
 	<A href='byond://?src=[REF(src)];automed_damage=-10'>-10</A>
 	<A href='byond://?src=[REF(src)];automed_damage=-5'>-5</A>
@@ -365,8 +366,11 @@
 	<A href='byond://?src=[REF(src)];automed_damage=5'>+5</A>
 	<A href='byond://?src=[REF(src)];automed_damage=10'>+10</A>
 	<A href='byond://?src=[REF(src)];automed_damage=50'>+50</A><BR>
+	<A href='byond://?src=[REF(src)];automed_damage=50'>+100</A>
+	<A href='byond://?src=[REF(src)];automed_damage=100'>+100</A><BR>
 	<BR>
 	<B>Pain Trigger Threshold (Max [SUIT_AUTODOC_DAM_MAX], Min [SUIT_AUTODOC_DAM_MIN]):</B><BR>
+	<A href='byond://?src=[REF(src)];automed_pain=-100'>-100</A><BR>
 	<A href='byond://?src=[REF(src)];automed_pain=-50'>-50</A>
 	<A href='byond://?src=[REF(src)];automed_pain=-10'>-10</A>
 	<A href='byond://?src=[REF(src)];automed_pain=-5'>-5</A>
@@ -374,7 +378,8 @@
 	<A href='byond://?src=[REF(src)];automed_pain=1'>+1</A>
 	<A href='byond://?src=[REF(src)];automed_pain=5'>+5</A>
 	<A href='byond://?src=[REF(src)];automed_pain=10'>+10</A>
-	<A href='byond://?src=[REF(src)];automed_pain=50'>+50</A><BR>"}
+	<A href='byond://?src=[REF(src)];automed_pain=50'>+50</A>
+	<A href='byond://?src=[REF(src)];automed_pain=100'>+100</A><BR>"}
 
 	var/datum/browser/popup = new(user, "Suit Automedic")
 	popup.set_content(dat)

--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -29,7 +29,7 @@
 	desc = "Designed for mounting on modular armor. This module has advanced medical systems that inject tricordrazine and tramadol based on the user's needs, as well as automatically securing the bones and body of the wearer, effectively splinting them until professional medical attention can be admistered. Will definitely impact mobility."
 	icon_state = "mod_autodoc"
 	item_state = "mod_autodoc_a"
-	slowdown = 0.3
+	slowdown = 0
 	slot = ATTACHMENT_SLOT_MODULE
 	variants_by_parent_type = list(/obj/item/clothing/suit/modular/xenonauten = "mod_autodoc_xn", /obj/item/clothing/suit/modular/xenonauten/light = "mod_autodoc_xn", /obj/item/clothing/suit/modular/xenonauten/heavy = "mod_autodoc_xn")
 	var/static/list/supported_limbs = list(CHEST, GROIN, ARM_LEFT, ARM_RIGHT, HAND_LEFT, HAND_RIGHT, LEG_LEFT, LEG_RIGHT, FOOT_LEFT, FOOT_RIGHT)


### PR DESCRIPTION
1.  Валькирия теперь не замедляет
2. Уменьшен и значительно увеличен диапазон настройки триггеров
50-150>>20-300
Это позволит тоньше настраивать и костыльно отключать ввод трико и трамадола, что позволит спокойно использовать в случае надобности парацетамол и рейталин. (да, я блять просто не смог сделать кнопки on и off)
3. Добавлены кнопки -100 и +100
4.  2 и 3 пункт относятся также к автомедику б18
