### PR TITLE
Динамическое изменение скейлинга сило

### DIFF
--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -23,6 +23,9 @@ SUBSYSTEM_DEF(silo)
 	//We are processing wether we hijacked or not (hijacking gives a bonus)
 	current_larva_spawn_rate *= SSmonitor.gamestate == SHIPSIDE ? 3 : 1
 	current_larva_spawn_rate *= SSticker.mode.silo_scaling
+	//Multiplier based on marines/xenos ratio
+	var/spawn_rate_multiplier = length_char(GLOB.humans_by_zlevel[SSmonitor.gamestate == SHIPSIDE ? "3" : "2"]) / ((2.5 * (xeno_job.total_positions - xeno_job.current_positions) + length_char(GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_tier[XENO_TIER_ZERO]) + length_char(GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_tier[XENO_TIER_ONE]) + length_char(GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_tier[XENO_TIER_TWO]) + length_char(GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_tier[XENO_TIER_THREE]) + length_char(GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_tier[XENO_TIER_FOUR])) + 1)
+	current_larva_spawn_rate *= clamp((spawn_rate_multiplier * spawn_rate_multiplier), 0.1, 2)
 	current_larva_spawn_rate += larva_spawn_rate_temporary_buff
 	GLOB.round_statistics.larva_from_silo += current_larva_spawn_rate / xeno_job.job_points_needed
 	xeno_job.add_job_points(current_larva_spawn_rate)


### PR DESCRIPTION
Сейчас спавн лярв от сило зависит исключительно от количества живых маринов на земле.

Данный ПР добавляет модификатор спавна, зависящий от соотношения живых ксенов к живым маринам.

Модификатор варьируется от 10% до 200%.

Модификатор равен 100% при соотношении 2,5 к 1 (например 40 маринов на 16 ксенов).

Сделано для того, что-бы ксены не получали слишком большого преимущества при долгом паритете, но в то-же время быстрее восстанавливались от крупных потерь.