### PR TITLE
Баффы горжера

### DIFF
--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -613,8 +613,13 @@
 		X.remove_status_effect(STATUS_EFFECT_XENO_FEAST)
 		return
 	var/heal_amount = X.maxHealth*0.08
-	HEAL_XENO_DAMAGE(X, heal_amount, FALSE)
-	adjustOverheal(X, heal_amount / 2)
+	for(var/mob/living/carbon/xenomorph/affected_xeno AS in GLOB.hive_datums[XENO_HIVE_NORMAL].xenos_by_zlevel["[X.z]"])
+		if(affected_xeno.faction != X.faction)
+			continue
+		if(!line_of_sight(X, affected_xeno, 4) || get_dist(X, affected_xeno) > 4)
+			continue
+		HEAL_XENO_DAMAGE(affected_xeno, heal_amount, FALSE)
+		adjustOverheal(affected_xeno, heal_amount / 2)
 	X.use_plasma(plasma_drain)
 
 // ***************************************

--- a/code/datums/status_effects/xeno_buffs.dm
+++ b/code/datums/status_effects/xeno_buffs.dm
@@ -562,6 +562,7 @@
 
 		if(do_after(owner_xeno, KNOCKDOWN_DURATION, FALSE, target, ignore_turf_checks = FALSE))
 			owner_xeno.gain_plasma(plasma_gain_on_hit)
+			target.blood_volume -= 10
 
 	if(owner_xeno.has_status_effect(STATUS_EFFECT_XENO_FEAST))
 		for(var/mob/living/carbon/xenomorph/target_xeno AS in cheap_get_xenos_near(owner_xeno, 4))

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -158,6 +158,7 @@
 
 	REMOVE_TRAIT(owner_xeno, TRAIT_HANDS_BLOCKED, src)
 	target_human.blur_eyes(1)
+	target_human.blood_volume -= 10
 	add_cooldown()
 
 #undef DO_DRAIN_ACTION
@@ -194,7 +195,7 @@
 
 	if(owner.do_actions)
 		return FALSE
-	if(!line_of_sight(owner, target_xeno, 2) || get_dist(owner, target_xeno) > 2)
+	if(!line_of_sight(owner, target_xeno, 3) || get_dist(owner, target_xeno) > 3)
 		if(!silent)
 			to_chat(owner, span_notice("It is beyond our reach, we must be close and our way must be clear."))
 		return FALSE
@@ -202,7 +203,7 @@
 		if(!silent)
 			to_chat(owner, span_notice("We can only help living sisters."))
 		return FALSE
-	if(!do_mob(owner, target_xeno, 1 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL))
+	if(!do_mob(owner, target_xeno, 1 SECONDS, BUSY_ICON_FRIENDLY, BUSY_ICON_MEDICAL, ignore_flags = IGNORE_LOC_CHANGE))
 		return FALSE
 	return TRUE
 
@@ -405,7 +406,7 @@
 	name = "Feast"
 	action_icon_state = "feast"
 	desc = "Enter a state of rejuvenation. During this time you use a small amount of blood and heal. You can cancel this early."
-	cooldown_timer = 180 SECONDS
+	cooldown_timer = 30 SECONDS
 	plasma_cost = 0
 	keybinding_signals = list(
 		KEYBINDING_NORMAL = COMSIG_XENOABILITY_FEAST,

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -158,7 +158,7 @@
 
 	REMOVE_TRAIT(owner_xeno, TRAIT_HANDS_BLOCKED, src)
 	target_human.blur_eyes(1)
-	target_human.blood_volume -= 10
+	target_human.blood_volume -= 20
 	add_cooldown()
 
 #undef DO_DRAIN_ACTION

--- a/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/gorger/abilities_gorger.dm
@@ -158,7 +158,7 @@
 
 	REMOVE_TRAIT(owner_xeno, TRAIT_HANDS_BLOCKED, src)
 	target_human.blur_eyes(1)
-	target_human.blood_volume -= 20
+	target_human.blood_volume -= 10
 	add_cooldown()
 
 #undef DO_DRAIN_ACTION


### PR DESCRIPTION
Баффы и удобства для бесполезной касты

- Feast теперь действует на всех ксеноморфов в радиусе 4 клеток, КД уменьшено с 180 до 30 сек
- Drain и Carnage сосут настоящую кровь у морпехов
- Transfusion не требует стоять на месте, дальность увеличена с 2 до 3 клеток