### PR TITLE
Вывод количества игроков в описание сервера

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -315,6 +315,7 @@ GLOBAL_VAR(restart_counter)
 	var/shipname = length_char(SSmapping?.configs) && SSmapping.configs[SHIP_MAP] ? SSmapping.configs[SHIP_MAP].map_name : "Lost in space..."
 	var/map_name = length_char(SSmapping.configs) && SSmapping.configs[GROUND_MAP] ? SSmapping.configs[GROUND_MAP].map_name : "Loading..."
 	var/ground_map_file = length_char(SSmapping.configs) && SSmapping.configs[GROUND_MAP] ? SSmapping.configs[GROUND_MAP].map_file : ""
+	var/players = GLOB.player_list
 
 	var/new_status = ""
 	new_status += "<b><a href='[discord_url ? discord_url : "#"]'>[server_name]</a></b>"
@@ -322,6 +323,7 @@ GLOBAL_VAR(restart_counter)
 	new_status += "<br>Ship: <b>[shipname]</b>"
 	new_status += "<br>Mode: <b>[SSticker.mode ? SSticker.mode.name : "Lobby"]</b>"
 	new_status += "<br>Round time: <b>[gameTimestamp("hh:mm")]</b>"
+	new_status += "<br>Players: <b>[players]</b>"
 
 	// Finally set the new status
 	status = new_status

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -322,8 +322,8 @@ GLOBAL_VAR(restart_counter)
 	new_status += "<br>Map: <a href='[webmap_host][ground_map_file]'><b>[map_name]</a></b>"
 	new_status += "<br>Ship: <b>[shipname]</b>"
 	new_status += "<br>Mode: <b>[SSticker.mode ? SSticker.mode.name : "Lobby"]</b>"
-	new_status += "<br>Round time: <b>[gameTimestamp("hh:mm")]</b>"
 	new_status += "<br>Players: <b>[players]</b>"
+	new_status += "<br>Round time: <b>[gameTimestamp("hh:mm")]</b>"
 
 	// Finally set the new status
 	status = new_status


### PR DESCRIPTION
## Зачем это нужно?
* Ну, это поможет мне парсить информацию о сервере прямиком из хаба, просто просеяв нужные строки, не прибегая к иным, более адекватным запросам.

* Я планировал изначально парсить через https://secure.byond.com/games/Exadv1/SpaceStation13?format=text, но там не выводится информация о приватных юзерах, подключённых к серверу, так что остаётся парсить через HTML-хуйню или внести вывод в описание в сам репозиторий билдули.

* По правде говоря, я это написал за две минуты, причём через веб-версию гитхаба, так что не ебу, работает ли эта ересь должным образом. Кому то это нужно подтвердить, потому что у меня сейчас возможности заняться этим нет.

* Господи, зачем я вообще этим занимаюсь? Но мне это довольно интересно, так что почему бы и нет.