### PR TITLE
Фикс вендоров вальхалы

### DIFF
--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -214,11 +214,12 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 	),
 	FACTION_VALHALLA = list(
 		/obj/machinery/vending/weapon/valhalla,
-		/obj/machinery/vending/uniform_supply,
-		/obj/machinery/vending/armor_supply,
+		/obj/machinery/vending/uniform_supply/valhalla,
+		/obj/machinery/vending/armor_supply/valhalla,
 		/obj/machinery/vending/marineFood,
 		/obj/machinery/vending/MarineMed/valhalla,
-		/obj/machinery/vending/cigarette,
+		/obj/machinery/vending/cigarette/nopower,
+		/obj/machinery/vending/tool/nopower,
 	),
 	SQUAD_CORPSMAN = list(
 		/obj/machinery/vending/medical/shipside,

--- a/code/datums/loadout/loadout_helper.dm
+++ b/code/datums/loadout/loadout_helper.dm
@@ -9,7 +9,7 @@
 ///Return true if the item was found in a linked vendor and successfully bought
 /proc/buy_item_in_vendor(obj/item/item_to_buy_type, datum/loadout_seller/seller, mob/living/user)
 
-	if(seller.faction != FACTION_NEUTRAL && is_type_in_typecache(item_to_buy_type, GLOB.hvh_restricted_items_list))
+	if(seller.faction != FACTION_VALHALLA && seller.faction != FACTION_NEUTRAL && SSticker.mode?.flags_round_type & MODE_HUMAN_ONLY && is_type_in_typecache(item_to_buy_type, GLOB.hvh_restricted_items_list))
 		return FALSE
 
 	//If we can find it for in a shared vendor, we buy it

--- a/code/game/objects/machinery/vending/marine_vending.dm
+++ b/code/game/objects/machinery/vending/marine_vending.dm
@@ -406,6 +406,7 @@
 /obj/machinery/vending/weapon/valhalla
 	resistance_flags = INDESTRUCTIBLE
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA
 	products = list(
 		"Rifles" = list(
 			/obj/item/weapon/gun/rifle/standard_assaultrifle = -1,
@@ -810,6 +811,7 @@
 
 /obj/machinery/vending/cigarette/nopower
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA
 
 /obj/machinery/vending/cargo_supply
 	name = "\improper Operational Supplies Vendor"
@@ -1080,6 +1082,7 @@
 /obj/machinery/vending/MarineMed/valhalla
 	resistance_flags = INDESTRUCTIBLE
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA
 	products = list(
 		"Pill Packet" = list(
 			/obj/item/storage/pill_bottle/packet/bicaridine = -1,
@@ -1266,6 +1269,7 @@
 /obj/machinery/vending/armor_supply/valhalla
 	resistance_flags = INDESTRUCTIBLE
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA
 
 /obj/machinery/vending/uniform_supply
 	name = "\improper Surplus Clothing Vendor"
@@ -1424,6 +1428,7 @@
 /obj/machinery/vending/uniform_supply/valhalla
 	resistance_flags = INDESTRUCTIBLE
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA
 
 /obj/machinery/vending/dress_supply
 	name = "\improper TerraGovTech dress uniform vendor"
@@ -1445,6 +1450,7 @@
 /obj/machinery/vending/dress_supply/valhalla
 	resistance_flags = INDESTRUCTIBLE
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA
 
 /obj/machinery/vending/valhalla_req
 	name = "\improper TerraGovTech requisition vendor"
@@ -1452,6 +1458,7 @@
 	icon_state = "requisitionop"
 	resistance_flags = INDESTRUCTIBLE
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA
 	products = list(
 		"Weapon" = list(
 			/obj/item/weapon/gun/energy/lasgun/lasrifle/tesla = -1,
@@ -1555,6 +1562,7 @@
 	icon_state = "requisitionop"
 	resistance_flags = INDESTRUCTIBLE
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA
 	products = list(
 		"Weapon" = list(
 			/obj/item/weapon/gun/revolver/small = -1,
@@ -1654,3 +1662,4 @@
 
 /obj/machinery/vending/tool/nopower
 	use_power = NO_POWER_USE
+	faction = FACTION_VALHALLA

--- a/code/game/objects/machinery/vending/new_marine_vendors.dm
+++ b/code/game/objects/machinery/vending/new_marine_vendors.dm
@@ -130,7 +130,7 @@
 			var/item_category = L[1]
 			var/cost = L[3]
 
-			if(SSticker.mode?.flags_round_type & MODE_HUMAN_ONLY && is_type_in_typecache(idx, GLOB.hvh_restricted_items_list))
+			if(faction != FACTION_VALHALLA && faction != FACTION_NEUTRAL && SSticker.mode?.flags_round_type & MODE_HUMAN_ONLY && is_type_in_typecache(idx, GLOB.hvh_restricted_items_list))
 				to_chat(usr, span_warning("This item is banned by the Space Geneva Convention."))
 				if(icon_deny)
 					flick(icon_deny, src)

--- a/code/game/objects/machinery/vending/vending.dm
+++ b/code/game/objects/machinery/vending/vending.dm
@@ -600,7 +600,7 @@
 		flick(icon_deny, src)
 		return
 
-	if(SSticker.mode?.flags_round_type & MODE_HUMAN_ONLY && is_type_in_typecache(R.product_path, GLOB.hvh_restricted_items_list))
+	if(faction != FACTION_VALHALLA && faction != FACTION_NEUTRAL && SSticker.mode?.flags_round_type & MODE_HUMAN_ONLY && is_type_in_typecache(R.product_path, GLOB.hvh_restricted_items_list))
 		to_chat(user, span_warning("This item is banned by the Space Geneva Convention."))
 		flick(icon_deny, src)
 		return


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Фикс лодаут вендора в вальхале. Теперь он выдает все предметы из лодаута. Фикс ксенаута в лодауте. Он теперь выдается нормально всегда.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Это должно было быть так
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
code: проверка на фракцию VALHALLA и режим игры при выдаче лодаута или венда предмета
code: вендоры вальхалы теперь имеют фракцию VALHALLA
fix: лист вендоров вальхалы
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
