### PR TITLE
Персональные пси поинты для ксенов

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -15,13 +15,20 @@ SUBSYSTEM_DEF(points)
 	///Assoc list of personal supply points
 	var/personal_supply_points = list()
 	///Personal supply points gain modifier
-	var/psp_multiplier = 0.05
+	var/psp_multiplier = 0.075
 	///Personal supply points limit
 	var/psp_limit = 600
 	///Var used to calculate points difference between updates
 	var/supply_points_old = 0
+
 	///Assoc list of xeno points: xeno_points_by_hive["hivenum"]
 	var/list/xeno_points_by_hive = list()
+	///Assoc list of personal psy points
+	var/personal_psy_points = list()
+	///Personal psy points gain modifier
+	var/ppp_multiplier = 0.1
+	///Personal psy points limit
+	var/ppp_limit = 100
 
 	var/ordernum = 1					//order number given to next order
 
@@ -95,6 +102,9 @@ SUBSYSTEM_DEF(points)
 	if(!CHECK_BITFIELD(SSticker.mode.flags_round_type, MODE_PSY_POINTS))
 		return
 	xeno_points_by_hive[hivenumber] += amount
+	for(var/mob/living/carbon/xenomorph/X in GLOB.alive_xeno_list)
+		if((X.hivenumber == hivenumber) || !(X.xeno_caste.caste_flags & CASTE_IS_A_MINION))
+			personal_psy_points[X.ckey] = min(personal_psy_points[X.ckey] + amount * ppp_multiplier, ppp_limit)
 
 
 /datum/controller/subsystem/points/proc/approve_request(datum/supply_order/O, mob/living/user)


### PR DESCRIPTION
Пока что все цифры тестовые.
Прирост - 10%
Лимит - 100
Матюрити и эволв по 30, примо по 50

Покупать во вкладке "Alien"

Ещё увеличил прирост персональных поинтов маринам с 5% до 7,5%