### PR TITLE
fix_vali_mod_abuse

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/modules.dm
+++ b/code/modules/clothing/modular_armor/attachments/modules.dm
@@ -271,6 +271,8 @@
 /obj/item/armor_module/module/chemsystem/on_detach(obj/item/detaching_from, mob/user)
 	var/datum/component/chem_booster/chemsystem = parent.GetComponent(/datum/component/chem_booster)
 	UnregisterSignal(chemsystem, COMSIG_CHEMSYSTEM_TOGGLED)
+	chemsystem.Destroy()
+	chemsystem.RemoveComponent()
 	chemsystem.RemoveComponent()
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
Вали теперь нельзя заабузить
Рантаймов не обнаружено
## Why It's Good For The Game
фикс абуза вали
B18 with vali_mod is myth
## Changelog
:cl:
fix: fix vali mod
/:cl: