### PR TITLE
Фикс лодаут вендора краша

### DIFF
--- a/_maps/shuttles/tgs_bigbury.dmm
+++ b/_maps/shuttles/tgs_bigbury.dmm
@@ -848,7 +848,7 @@
 /turf/open/floor/mainship/red/full,
 /area/shuttle/canterbury)
 "Fl" = (
-/obj/machinery/loadout_vendor,
+/obj/machinery/loadout_vendor/crash,
 /turf/open/floor/mainship/mono,
 /area/shuttle/canterbury)
 "FQ" = (

--- a/_maps/shuttles/tgs_canterbury.dmm
+++ b/_maps/shuttles/tgs_canterbury.dmm
@@ -249,7 +249,7 @@
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aO" = (
-/obj/machinery/loadout_vendor,
+/obj/machinery/loadout_vendor/crash,
 /turf/open/floor/mainship/cargo,
 /area/shuttle/canterbury)
 "aP" = (

--- a/code/__DEFINES/factions.dm
+++ b/code/__DEFINES/factions.dm
@@ -19,6 +19,7 @@
 #define FACTION_HOSTILE "Hostile"
 #define FACTION_PIRATE "Pirate"
 #define FACTION_VALHALLA "Valhalla"
+#define FACTION_NEUTRAL_CRASH "Neutral Crash"
 
 //Alignement are currently only used by req.
 ///Mob with a neutral alignement cannot be sold by anyone

--- a/code/__DEFINES/loadout.dm
+++ b/code/__DEFINES/loadout.dm
@@ -194,6 +194,15 @@ GLOBAL_LIST_INIT(loadout_linked_vendor, list(
 		/obj/machinery/vending/cigarette,
 		/obj/machinery/vending/tool,
 	),
+	FACTION_NEUTRAL_CRASH = list(
+		/obj/machinery/vending/weapon/crash,
+		/obj/machinery/vending/uniform_supply,
+		/obj/machinery/vending/armor_supply,
+		/obj/machinery/vending/marineFood,
+		/obj/machinery/vending/MarineMed,
+		/obj/machinery/vending/cigarette,
+		/obj/machinery/vending/tool,
+	),
 	FACTION_TERRAGOV = list(
 		/obj/machinery/vending/weapon/hvh/team_one,
 		/obj/machinery/vending/uniform_supply,

--- a/code/game/objects/machinery/vending/loadout_vendor.dm
+++ b/code/game/objects/machinery/vending/loadout_vendor.dm
@@ -11,6 +11,9 @@
 	///The faction of this loadout vendor
 	var/faction = FACTION_NEUTRAL
 
+/obj/machinery/loadout_vendor/crash
+	faction = FACTION_NEUTRAL_CRASH
+
 /obj/machinery/loadout_vendor/can_interact(mob/user)
 	. = ..()
 	if(!.)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Теперь вендоры лодаутов будут давать оружие из оружейного вендора краша, а не обычного
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Не берут через абуз миномет, трубу и тд
<!-- Argue for the merits of your changes and how they benefit the game, especially if they are controversial and/or far reaching. If you can't actually explain WHY what you are doing will improve the game, then it probably isn't good for the game in the first place. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: новая фракция FACTION_NEUTRAL_CRASH
add: вариация лодаут вендора для краша
add: вендоры в список фракции FACTION_NEUTRAL_CRASH
code: заменена лодаут вендоров на кораблях краша
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
