### PR TITLE
Fix evac pod ghost

### DIFF
--- a/code/game/objects/machinery/cryopod.dm
+++ b/code/game/objects/machinery/cryopod.dm
@@ -268,7 +268,7 @@
 	if(helper && user != helper)
 		if(user.stat == DEAD)
 			to_chat(helper, span_notice("[user] is dead!"))
-			return
+			return FALSE
 
 		helper.visible_message(span_notice("[helper] starts putting [user] into [src]."),
 		span_notice("You start putting [user] into [src]."))
@@ -278,16 +278,17 @@
 
 	var/mob/initiator = helper ? helper : user
 	if(!do_after(initiator, 20, TRUE, user, BUSY_ICON_GENERIC))
-		return
+		return FALSE
 
 	if(!QDELETED(occupant))
 		to_chat(initiator, span_warning("[src] is occupied."))
-		return
+		return FALSE
 
 	user.forceMove(src)
 
 	occupant = user
 	update_icon()
+	return TRUE
 
 /obj/machinery/cryopod/proc/go_out()
 	if(QDELETED(occupant))

--- a/code/modules/shuttle/escape_pod.dm
+++ b/code/modules/shuttle/escape_pod.dm
@@ -159,7 +159,8 @@
 
 /obj/machinery/cryopod/evacuation/climb_in(mob/living/carbon/user, mob/helper)
 	. = ..()
-	user.ghostize(FALSE)
+	if(.)
+		user.ghostize(FALSE)
 
 /obj/machinery/door/airlock/evacuation
 	name = "\improper Evacuation Airlock"


### PR DESCRIPTION
## About The Pull Request
orig pr
https://github.com/tgstation/TerraGov-Marine-Corps/pull/12715#issue-1665979895
## Why It's **Bad** For The Game
не будет смешного

## Changelog

:cl:
fix: Cancelling the channel to enter a cryo pod on the evac shuttle will no longer ghost you.
/:cl:
