### PR TITLE
Предотвращение гриферства гипоспреями и автоинжекторами

### DIFF
--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -152,8 +152,9 @@
 
 	if(ismob(A))
 		var/mob/M = A
+		user.visible_message(span_warning("[user] injects [M] with the [src]!"))
 		to_chat(user, "[span_notice("You inject [M] with [src]")].")
-		to_chat(M, span_warning("You feel a tiny prick!"))
+		to_chat(M, span_notice("[user] injects you with [src]!"))
 
 	// /mob/living/carbon/human/attack_hand causes
 	// changeNext_move(7) which creates a delay

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -153,7 +153,7 @@
 	if(ismob(A))
 		var/mob/M = A
 		user.visible_message(span_warning("[user] injects [M] with [src]!"))
-		to_chat(user, "[span_notice("You inject [M] with [src]")].")
+		to_chat(user, span_notice("You inject [M] with [src]."))
 		to_chat(M, span_notice("[user] injects you with [src]!"))
 
 	// /mob/living/carbon/human/attack_hand causes

--- a/code/game/objects/items/reagent_containers/hypospray.dm
+++ b/code/game/objects/items/reagent_containers/hypospray.dm
@@ -152,7 +152,7 @@
 
 	if(ismob(A))
 		var/mob/M = A
-		user.visible_message(span_warning("[user] injects [M] with the [src]!"))
+		user.visible_message(span_warning("[user] injects [M] with [src]!"))
 		to_chat(user, "[span_notice("You inject [M] with [src]")].")
 		to_chat(M, span_notice("[user] injects you with [src]!"))
 


### PR DESCRIPTION
Теперь объекту показывает имя субъекта использовавшего гипоспрей и автоинжектор. Нужная фича в время отсутствия администрации, которая поможет найти виновного.