### PR TITLE
personal pry point nerf.

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -26,7 +26,7 @@ SUBSYSTEM_DEF(points)
 	///Assoc list of personal psy points
 	var/personal_psy_points = list()
 	///Personal psy points gain modifier
-	var/ppp_multiplier = 0.1
+	var/ppp_multiplier = 0.016
 	///Personal psy points limit
 	var/ppp_limit = 100
 

--- a/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
+++ b/code/modules/mob/living/carbon/xenomorph/xenoprocs.dm
@@ -52,7 +52,7 @@
 
 /proc/buy_personal_blessings(mob/user)
 	var/upgrade_cost = 30
-	var/evolution_cost = 30
+	var/evolution_cost = 20
 	var/primo_cost = 50
 	var/dat = "<br><b>Avaliable Options:</b><BR>"
 


### PR DESCRIPTION
## About The Pull Request

Уменьшение начисления пси поинтов с 0.1 до 0.016 в секунду (2 в минуту).
Так же понизил цену эво апгрейда с 30 до 20 

## Why It's Good For The Game

Сейчас персональные поинты слишком сильны.
