### PR TITLE
Front armor xeno

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/crusher/crusher.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/crusher/crusher.dm
@@ -66,3 +66,16 @@
 
 /mob/living/carbon/xenomorph/crusher/resisted_against(datum/source)
 	user_unbuckle_mob(source, source)
+
+// ***************************************
+// *********** Front Armor
+// ***************************************
+
+/mob/living/carbon/xenomorph/crusher/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(SEND_SIGNAL(src, COMSIG_XENO_PROJECTILE_HIT, proj, cardinal_move, uncrossing) & COMPONENT_PROJECTILE_DODGE)
+		return FALSE
+	if(proj.ammo.flags_ammo_behavior & AMMO_SKIPS_ALIENS)
+		return FALSE
+	if((cardinal_move & REVERSE_DIR(dir)))
+		proj.damage -= proj.damage * (0.7 * get_sunder())
+	return ..()

--- a/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/queen/queen.dm
@@ -115,3 +115,16 @@
 /mob/living/carbon/xenomorph/queen/proc/is_burrowed_larva_host(datum/source, list/mothers, list/silos)
 	if(!incapacitated(TRUE))
 		mothers += src //Adding us to the list.
+
+// ***************************************
+// *********** Front Armor
+// ***************************************
+
+/mob/living/carbon/xenomorph/queen/projectile_hit(obj/projectile/proj, cardinal_move, uncrossing)
+	if(SEND_SIGNAL(src, COMSIG_XENO_PROJECTILE_HIT, proj, cardinal_move, uncrossing) & COMPONENT_PROJECTILE_DODGE)
+		return FALSE
+	if(proj.ammo.flags_ammo_behavior & AMMO_SKIPS_ALIENS)
+		return FALSE
+	if((cardinal_move & REVERSE_DIR(dir)))
+		proj.damage -= proj.damage * (0.5 * get_sunder())
+	return ..()

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -840,6 +840,8 @@ So if we are on the 32th absolute pixel coordinate we are on tile 1, but if we a
 		return FALSE
 	if(proj.ammo.flags_ammo_behavior & AMMO_SKIPS_ALIENS)
 		return FALSE
+	if(is_charging >= CHARGE_ON)
+		proj.damage -= proj.damage * (0.2 * get_sunder())
 	return ..()
 
 


### PR DESCRIPTION
## About The Pull Request

У ксено появился порез урона проджектайлов, если они повёрнуты к ним мордой.

Что мы имеем
Если крашер повёрнут лицом к проджектайлу (на мили не работает, на ножи, гранаты и т.д не работает)
И между ними есть хотя бы одна клетка
У проджекта урон режется на 70 процентов, до начала работы брони
Эти проценты уменьшаются от сандера.

Квина имеет деф 50 процентов
Уменьшается от сандера (и остальные условия)

Если какой либо ксенос находится в чарже, он блокирует 20 процентов урона, до работы брони
Уменьшается от сандера ( не нужно быть повёрнутым головой к пули, но остальные условия работают)
