### PR TITLE
Больше поинтов КАСу

### DIFF
--- a/code/controllers/subsystem/points.dm
+++ b/code/controllers/subsystem/points.dm
@@ -1,5 +1,5 @@
 // points per minute
-#define DROPSHIP_POINT_RATE 18 * ((GLOB.current_orbit+3)/6)
+#define DROPSHIP_POINT_RATE 26 * ((GLOB.current_orbit+3)/6)
 #define SUPPLY_POINT_RATE 20 * (GLOB.current_orbit/3)
 
 SUBSYSTEM_DEF(points)


### PR DESCRIPTION
Теперь в минуту будет капать не 18, а 26 поитов в фабрикатор авиации, причина тому: Вырезание карточек в карго, большие цены на ракеты и их малая эффективность.