### PR TITLE
Пробное понижение цен

### DIFF
--- a/code/game/objects/structures/dropship_ammo.dm
+++ b/code/game/objects/structures/dropship_ammo.dm
@@ -397,7 +397,7 @@
 	icon_state = "single"
 	travelling_time = 3 SECONDS //not powerful, but reaches target fast
 	ammo_id = ""
-	point_cost = 75
+	point_cost = 50
 	devastating_explosion_range = 2
 	heavy_explosion_range = 4
 	light_explosion_range = 7
@@ -414,7 +414,7 @@
 	desc = "The AGM-227 missile is a mainstay of the overhauled dropship fleet against any mobile or armored ground targets. It's earned the nickname of 'Banshee' from the sudden wail that it emitts right before hitting a target. Useful to clear out large areas. Moving this will require some sort of lifter."
 	icon_state = "banshee"
 	ammo_id = "b"
-	point_cost = 150
+	point_cost = 100
 	devastating_explosion_range = 2
 	heavy_explosion_range = 4
 	light_explosion_range = 7
@@ -432,7 +432,7 @@
 	desc = "The GBU-67 'Keeper II' is the latest in a generation of laser guided weaponry that spans all the way back to the 20th century. Earning its nickname from a shortening of 'Peacekeeper' which comes from the program that developed its guidance system and the various uses of it during peacekeeping conflicts. Its payload is designed to devastate armored targets. Moving this will require some sort of lifter."
 	icon_state = "keeper"
 	ammo_id = "k"
-	point_cost = 300
+	point_cost = 250
 	devastating_explosion_range = 4
 	heavy_explosion_range = 4
 	light_explosion_range = 5
@@ -448,7 +448,7 @@
 	desc = "The SM-17 'Fatty' is the most devestating rocket in TGMC arsenal, only second after its big cluster brother in Orbital Cannon. These rocket are also known for highest number of Friendly-on-Friendly incidents due to secondary cluster explosions as well as range of these explosions, TGMC recommends pilots to encourage usage of signal flares or laser for 'Fatty' support. Moving this will require some sort of lifter."
 	icon_state = "fatty"
 	ammo_id = "f"
-	point_cost = 250
+	point_cost = 200
 	devastating_explosion_range = 2
 	heavy_explosion_range = 3
 	light_explosion_range = 4
@@ -512,7 +512,7 @@
 	ammo_name = "minirocket"
 	travelling_time = 4 SECONDS
 	transferable_ammo = TRUE
-	point_cost = 100
+	point_cost = 85
 	ammo_type = CAS_MINI_ROCKET
 	devastating_explosion_range = 0
 	heavy_explosion_range = 2
@@ -548,7 +548,7 @@
 	name = "incendiary mini rocket stack"
 	desc = "A pack of laser guided incendiary mini rockets. Moving this will require some sort of lifter."
 	icon_state = "minirocket_inc"
-	point_cost = 200
+	point_cost = 150
 	light_explosion_range = 3 //Slightly weaker than standard minirockets
 	fire_range = 3 //Fire range should be the same as the explosion range. Explosion should leave fire, not vice versa
 	prediction_type = CAS_AMMO_INCENDIARY
@@ -581,7 +581,7 @@
 	name = "Tanglefoot mini rocket stack"
 	desc = "A pack of laser guided mini rockets loaded with plasma-draining Tanglefoot gas. Moving this will require some sort of lifter."
 	icon_state = "minirocket_tfoot"
-	point_cost = 150
+	point_cost = 100
 	devastating_explosion_range = 0
 	heavy_explosion_range = 0
 	light_explosion_range = 2


### PR DESCRIPTION
Количество поступления поинтов мы увеличили, теперь время и цены поставить пониже, копить 300 поинтов, когда идет плотная война совсем не круто ради одного выстрела.

Далее по списку:

Видовмекер(самая дешевая ракета) - 75 > 50
Банши(зажигательная) - 150 >100
Кипер(самая дорогая, но самая бесполезная ракета) - 300 > 250
Толстушка(тоже самое что банши, только с газом) - 250 > 200

Теперь миниракеты, их всегда очень не хватает из-за цены, слишком много поинтов уходит в обычные ракеты такие как: Банши или вдова.

Миниракеты обычные - 100 > 85
Зажигательные - 200 > 150
Газовая(самая забуленная и малоиспользуемая) - 150 > 100.

