### PR TITLE
Fix tadpole gun (for real this time)

### DIFF
--- a/_maps/map_files/Minerva/TGS_Minerva.dmm
+++ b/_maps/map_files/Minerva/TGS_Minerva.dmm
@@ -14208,7 +14208,7 @@
 /turf/open/floor/mainship/research,
 /area/mainship/medical/medical_science)
 "PB" = (
-/obj/structure/dropship_equipment/mg_holder,
+/obj/structure/dropship_equipment/weapon_holder/machinegun,
 /turf/open/floor/mainship/cargo,
 /area/mainship/hallways/hangar)
 "PC" = (

--- a/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
+++ b/_maps/map_files/Pillar_of_Spring/TGS_Pillar_of_Spring.dmm
@@ -11749,7 +11749,7 @@
 "phr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/dropship_equipment/mg_holder,
+/obj/structure/dropship_equipment/weapon_holder/machinegun,
 /turf/open/floor/mainship/office,
 /area/mainship/hallways/hangar)
 "pid" = (

--- a/_maps/map_files/Sulaco/TGS_Sulaco.dmm
+++ b/_maps/map_files/Sulaco/TGS_Sulaco.dmm
@@ -18721,7 +18721,7 @@
 /area/sulaco/maintenance/lower_maint2)
 "mRR" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/dropship_equipment/mg_holder,
+/obj/structure/dropship_equipment/weapon_holder/machinegun,
 /obj/machinery/light/mainship{
 	light_color = "#da2f1b"
 	},

--- a/_maps/map_files/Talos/TGS_Talos.dmm
+++ b/_maps/map_files/Talos/TGS_Talos.dmm
@@ -24083,7 +24083,7 @@
 /obj/machinery/light/mainship{
 	dir = 8
 	},
-/obj/structure/dropship_equipment/mg_holder,
+/obj/structure/dropship_equipment/weapon_holder/machinegun,
 /turf/open/floor/mainship/floor,
 /area/mainship/hallways/hangar)
 "spd" = (

--- a/_maps/map_files/Theseus/TGS_Theseus.dmm
+++ b/_maps/map_files/Theseus/TGS_Theseus.dmm
@@ -20060,7 +20060,7 @@
 /turf/open/floor/mainship/purple/full,
 /area/mainship/hallways/hangar)
 "xjo" = (
-/obj/structure/dropship_equipment/mg_holder,
+/obj/structure/dropship_equipment/weapon_holder/machinegun,
 /turf/open/floor/mainship/mono,
 /area/mainship/hallways/hangar)
 "xjw" = (

--- a/_maps/map_files/debugdalus/tgs_debugdalus.dmm
+++ b/_maps/map_files/debugdalus/tgs_debugdalus.dmm
@@ -2283,7 +2283,7 @@
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "bEy" = (
-/obj/structure/dropship_equipment/mg_holder,
+/obj/structure/dropship_equipment/weapon_holder/machinegun,
 /turf/open/floor/mainship,
 /area/mainship/hallways/hangar)
 "bOe" = (

--- a/code/game/objects/structures/dropship_equipment.dm
+++ b/code/game/objects/structures/dropship_equipment.dm
@@ -490,211 +490,93 @@
 	sentry_type = /obj/item/weapon/gun/sentry/big_sentry/dropship/rebel
 
 
-/obj/structure/dropship_equipment/mg_holder
+/obj/structure/dropship_equipment/weapon_holder
+	equip_category = DROPSHIP_CREW_WEAPON
+	///The type of deployable that this holder holds
+	var/obj/machinery/deployable/deployable_type
+	///The reference to the deployable itself
+	var/obj/machinery/deployable/held_deployable
+	///The sprite used when we are deployed
+	var/deployed_icon_state = "mg_system_deployed"
+	///The sprite used when we aren't deployed
+	var/undeployed_icon_state = "mg_system"
+
+/obj/structure/dropship_equipment/weapon_holder/Initialize()
+	. = ..()
+	if(held_deployable)
+		return
+	var/obj/machinery/deployable/new_deployable = new deployable_type(src)
+	held_deployable = new_deployable.loc //new_deployable.loc, since it deploys on new(), is located within the held_deployable. Therefore new_deployable.loc = held_deployable.
+
+/obj/structure/dropship_equipment/weapon_holder/examine(mob/user)
+	. = ..()
+	if(!held_deployable)
+		. += "Its [initial(deployable_type.name)] is missing."
+
+/obj/structure/dropship_equipment/weapon_holder/update_equipment()
+	if(!held_deployable)
+		return
+	if(ship_base)
+		held_deployable.loc = loc
+	else
+		held_deployable.loc = src
+	update_icon()
+
+/obj/structure/dropship_equipment/weapon_holder/update_icon_state()
+	if(ship_base)
+		icon_state = deployed_icon_state
+	else
+		icon_state = undeployed_icon_state
+
+/obj/structure/dropship_equipment/weapon_holder/Destroy()
+	if(held_deployable)
+		QDEL_NULL(held_deployable)
+	return ..()
+
+/obj/structure/dropship_equipment/weapon_holder/CanAllowThrough(atom/movable/mover, turf/target)
+	. = ..()
+	if(held_deployable.loc != src)
+		return TRUE
+
+/obj/structure/dropship_equipment/weapon_holder/machinegun
 	name = "machinegun deployment system"
 	desc = "A box that deploys a modified M56D crewserved machine gun. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
-	equip_category = DROPSHIP_CREW_WEAPON
 	icon_state = "mg_system"
 	point_cost = 300
-	density = 0
-	///machine type for the internal gun and for checking if the gun is deployed
-	var/obj/machinery/deployable/mounted/deployed_mg
+	deployable_type = /obj/item/weapon/gun/tl102/hsg_nest
 
-/obj/structure/dropship_equipment/mg_holder/Initialize()
-	. = ..()
-	if(deployed_mg)
-		return
-	var/obj/item/weapon/gun/tl102/hsg_nest/new_gun = new(src)
-	deployed_mg = new_gun.loc //new_gun.loc, since it deploys on new(), is located within the deployed_mg. Therefore new_gun.loc = deployed_mg.
-
-/obj/structure/dropship_equipment/mg_holder/examine(mob/user)
-	. = ..()
-	if(!deployed_mg)
-		. += "Its machine gun is missing."
-
-/obj/structure/dropship_equipment/mg_holder/update_equipment()
-	if(!deployed_mg)
-		return
-	if(ship_base)
-		deployed_mg.loc = loc
-	else
-		deployed_mg.loc = src
-	update_icon()
-
-/obj/structure/dropship_equipment/mg_holder/update_icon_state()
-	if(ship_base)
-		icon_state = "mg_system_deployed"
-	else
-		icon_state = "mg_system"
-
-/obj/structure/dropship_equipment/mg_holder/Destroy()
-	if(deployed_mg)
-		QDEL_NULL(deployed_mg)
-	return ..()
-
-/obj/structure/dropship_equipment/minigun_holder
+/obj/structure/dropship_equipment/weapon_holder/minigun
 	name = "minigun deployment system"
 	desc = "A box that deploys a modified MG-2005 crewserved minigun. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
-	equip_category = DROPSHIP_CREW_WEAPON
 	icon_state = "minigun_system"
 	point_cost = 0 //this removes it from the fabricator
-	///machine type for the internal gun and for checking if the gun is deployed
-	var/obj/machinery/deployable/mounted/deployed_minigun
+	deployable_type = /obj/item/weapon/gun/standard_minigun/nest
+	undeployed_icon_state = "minigun_system"
 
-/obj/structure/dropship_equipment/minigun_holder/Initialize()
-	. = ..()
-	if(deployed_minigun)
-		return
-	var/obj/item/weapon/gun/standard_minigun/nest/new_gun = new(src)
-	deployed_minigun = new_gun.loc //new_gun.loc, since it deploys on new(), is located within the deployed_minigun. Therefore new_gun.loc = deployed_minigun.
-
-/obj/structure/dropship_equipment/minigun_holder/examine(mob/user)
-	. = ..()
-	if(!deployed_minigun)
-		. += "Its minigun is missing."
-
-/obj/structure/dropship_equipment/minigun_holder/update_equipment()
-	if(!deployed_minigun)
-		return
-	if(ship_base)
-		deployed_minigun.loc = loc
-	else
-		deployed_minigun.loc = src
-	update_icon()
-
-/obj/structure/dropship_equipment/minigun_holder/update_icon_state()
-	if(ship_base)
-		icon_state = "mg_system_deployed"
-	else
-		icon_state = "minigun_system"
-
-/obj/structure/dropship_equipment/minigun_holder/Destroy()
-	if(deployed_minigun)
-		QDEL_NULL(deployed_minigun)
-	return ..()
-
-/obj/structure/dropship_equipment/heavylaser_holder
+/obj/structure/dropship_equipment/weapon_holder/heavylaser
 	name = "heavy laser deployment system"
 	desc = "A box that deploys a modified TE-9001 crewserved heavylaser. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
-	equip_category = DROPSHIP_CREW_WEAPON
 	icon_state = "hl_system"
 	point_cost = 0 //this removes it from the fabricator
-	///machine type for the internal gun and for checking if the gun is deployed
-	var/obj/machinery/deployable/mounted/deployed_heavylaser
+	deployable_type = /obj/item/weapon/gun/heavy_laser
+	undeployed_icon_state = "hl_system"
 
-/obj/structure/dropship_equipment/heavylaser_holder/Initialize()
-	. = ..()
-	if(deployed_heavylaser)
-		return
-	var/obj/item/weapon/gun/heavy_laser/new_gun = new(src)
-	deployed_heavylaser = new_gun.loc //new_gun.loc, since it deploys on new(), is located within the deployed_heavylaser. Therefore new_gun.loc = deployed_heavylaser.
-
-/obj/structure/dropship_equipment/heavylaser_holder/examine(mob/user)
-	. = ..()
-	if(!deployed_heavylaser)
-		. += "Its heavy laser is missing."
-
-/obj/structure/dropship_equipment/heavylaser_holder/update_equipment()
-	if(!deployed_heavylaser)
-		return
-	if(ship_base)
-		deployed_heavylaser.loc = loc
-	else
-		deployed_heavylaser.loc = src
-	update_icon()
-
-/obj/structure/dropship_equipment/heavylaser_holder/update_icon_state()
-	if(ship_base)
-		icon_state = "mg_system_deployed"
-	else
-		icon_state = "hl_system"
-
-/obj/structure/dropship_equipment/heavylaser_holder/Destroy()
-	if(deployed_heavylaser)
-		QDEL_NULL(deployed_heavylaser)
-	return ..()
-
-/obj/structure/dropship_equipment/heavy_rr_holder
+/obj/structure/dropship_equipment/weapon_holder/heavy_rr
 	name = "heavy recoilless rifle deployment system"
 	desc = "A box that deploys a modified RR-15 crewserved recoilless rifle. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
-	equip_category = DROPSHIP_CREW_WEAPON
 	icon_state = "rr_system"
 	point_cost = 0 //this removes it from the fabricator
-	///machine type for the internal gun and for checking if the gun is deployed
-	var/obj/machinery/deployable/mounted/deployed_heavyrr
+	deployable_type = /obj/item/weapon/gun/launcher/rocket/heavy_rr
+	undeployed_icon_state = "rr_system"
 
-/obj/structure/dropship_equipment/heavy_rr_holder/Initialize()
-	. = ..()
-	if(deployed_heavyrr)
-		return
-	var/obj/item/weapon/gun/launcher/rocket/heavy_rr/new_gun = new(src)
-	deployed_heavyrr = new_gun.loc //new_gun.loc, since it deploys on new(), is located within the deployed_heavyrr. Therefore new_gun.loc = deployed_heavyrr.
-
-/obj/structure/dropship_equipment/heavy_rr_holder/examine(mob/user)
-	. = ..()
-	if(!deployed_heavyrr)
-		. += "Its recoilless rifle is missing."
-
-/obj/structure/dropship_equipment/heavy_rr_holder/update_equipment()
-	if(!deployed_heavyrr)
-		return
-	if(ship_base)
-		deployed_heavyrr.loc = loc
-	else
-		deployed_heavyrr.loc = src
-	update_icon()
-
-/obj/structure/dropship_equipment/heavy_rr_holder/update_icon_state()
-	if(ship_base)
-		icon_state = "mg_system_deployed"
-	else
-		icon_state = "rr_system"
-
-/obj/structure/dropship_equipment/heavy_rr_holder/Destroy()
-	if(deployed_heavyrr)
-		QDEL_NULL(deployed_heavyrr)
-	return ..()
-
-/obj/structure/dropship_equipment/mortar_holder
+/obj/structure/dropship_equipment/weapon_holder/mortar_holder
 	name = "mortar deployment system"
 	desc = "A box that deploys a TA-55DB mortar. Fits on the crewserved weapon attach points of dropships. You need a powerloader to lift it."
-	equip_category = DROPSHIP_CREW_WEAPON
 	icon_state = "mortar_system"
 	point_cost = 300
-	///machine type for the internal gun and for checking if the gun is deployed
-	var/obj/machinery/deployable/mortar/double/deployed_mortar
+	deployable_type = /obj/item/mortar_kit/double
 
-/obj/structure/dropship_equipment/mortar_holder/Initialize()
-	. = ..()
-	if(deployed_mortar)
-		return
-	var/obj/item/mortar_kit/double/new_gun = new(src)
-	deployed_mortar = new_gun.loc //new_gun.loc, since it deploys on new(), is located within the deployed_mortar. Therefore new_gun.loc = deployed_mg.
 
-/obj/structure/dropship_equipment/mortar_holder/examine(mob/user)
-	. = ..()
-	if(!deployed_mortar)
-		. += "Its mortar is missing."
-
-/obj/structure/dropship_equipment/mortar_holder/update_equipment()
-	if(!deployed_mortar)
-		return
-	if(ship_base)
-		deployed_mortar.loc = loc
-	else
-		deployed_mortar.loc = src
-	update_icon()
-
-/obj/structure/dropship_equipment/mortar_holder/update_icon_state()
-	if(ship_base)
-		icon_state = "mg_system_deployed"
-	else
-		icon_state = "mg_system"
-
-/obj/structure/dropship_equipment/mortar_holder/Destroy()
-	if(deployed_mortar)
-		QDEL_NULL(deployed_mortar)
-	return ..()
 ////////////////////////////////// FUEL EQUIPMENT /////////////////////////////////
 
 /obj/structure/dropship_equipment/fuel

--- a/code/modules/projectiles/guns/mounted.dm
+++ b/code/modules/projectiles/guns/mounted.dm
@@ -63,7 +63,7 @@
 	deployable_item = /obj/machinery/deployable/mounted
 
 	max_integrity = 200
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
 
 ///Unmovable ship mounted version.
 /obj/item/weapon/gun/tl102/hsg_nest
@@ -84,7 +84,7 @@
 		/obj/item/ammo_magazine/tl102/hsg_nest,
 	)
 	flags_item =  IS_DEPLOYABLE|TWOHANDED|DEPLOYED_NO_PICKUP|DEPLOY_ON_INITIALIZE
-	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
 /obj/item/weapon/gun/tl102/hsg_nest/sandless
 	icon_state = "entrenched_sandless"
@@ -131,7 +131,7 @@
 	deployable_item = /obj/machinery/deployable/mounted
 
 	max_integrity = 300
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
 
 ///Unmovable ship mounted version.
 /obj/item/weapon/gun/standard_minigun/nest
@@ -146,7 +146,7 @@
 
 	starting_attachment_types = list(/obj/item/attachable/scope/unremovable/tl102/nest,)
 
-	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
 
 //-------------------------------------------------------
 //ATR-22 mounted heavy anti-air gun
@@ -188,11 +188,11 @@
 	deployable_item = /obj/machinery/deployable/mounted/moveable/auto_cannon
 
 	max_integrity = 500
-	soft_armor = list(MELEE = 60, BULLET = 50, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 60, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
 /obj/machinery/deployable/mounted/moveable/auto_cannon
 	resistance_flags = XENO_DAMAGEABLE|UNACIDABLE
-	coverage = 75 //has a shield
+	coverage = 85 //has a shield
 
 //-------------------------------------------------------
 //TE-9001 mounted heavy laser
@@ -230,7 +230,7 @@
 	deployable_item = /obj/machinery/deployable/mounted
 
 	max_integrity = 400
-	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
 //-------------------------------------------------------
 //RR-15 mounted heavy recoilless rifle
@@ -273,7 +273,7 @@
 	deployable_item = /obj/machinery/deployable/mounted
 
 	max_integrity = 600
-	soft_armor = list(MELEE = 0, BULLET = 100, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
 ///This is my meme version, the first version of the HSG-102 to have auto-fire, revel in its presence.
 /obj/item/weapon/gun/tl102/death
@@ -335,7 +335,7 @@
 	deployable_item = /obj/machinery/deployable/mounted/moveable
 
 	max_integrity = 200
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
 
 
 
@@ -387,7 +387,7 @@
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_fire_delay = 0.1 SECONDS
 	aim_speed_modifier = 5
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
 
 	scatter = 30 // you're not firing this standing.
@@ -439,7 +439,7 @@
 	actions_types = list(/datum/action/item_action/aim_mode)
 	aim_time = 6 SECONDS
 	reciever_flags = AMMO_RECIEVER_MAGAZINES|AMMO_RECIEVER_AUTO_EJECT
-	soft_armor = list(MELEE = 60, BULLET = 50, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
+	soft_armor = list(MELEE = 60, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 0)
 
 	scatter = 0
 	recoil = 3
@@ -452,7 +452,7 @@
 /obj/machinery/deployable/mounted/moveable/atgun
 	var/obj/item/storage/internal/ammo_rack/sponson = /obj/item/storage/internal/ammo_rack
 	resistance_flags = XENO_DAMAGEABLE|UNACIDABLE
-	coverage = 75 //has a shield
+	coverage = 85 //has a shield
 
 /obj/item/storage/internal/ammo_rack
 	storage_slots = 10
@@ -525,7 +525,7 @@
 
 
 	max_integrity = 300
-	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 0, ENERGY = 0, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
+	soft_armor = list(MELEE = 0, BULLET = 50, LASER = 50, ENERGY = 50, BOMB = 50, BIO = 100, FIRE = 0, ACID = 20)
 
 
 

--- a/code/modules/projectiles/mounted.dm
+++ b/code/modules/projectiles/mounted.dm
@@ -126,6 +126,7 @@
 	if(!user.Move(loc)) //Move instead of forcemove to ensure we can actually get to the object's turf
 		density = initial(density)
 		return
+	density = initial(density)
 
 	playsound(loc, 'sound/weapons/thudswoosh.ogg', 25, TRUE, 7)
 	do_attack_animation(src, ATTACK_EFFECT_GRAB)

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -1753,23 +1753,34 @@ VEHICLES
 
 /datum/supply_packs/vehicles/mounted_hsg
 	name = "Mounted HSG"
-	contains = list(/obj/structure/dropship_equipment/mg_holder)
+	contains = list(/obj/structure/dropship_equipment/weapon_holder/machinegun)
 	cost = 500
+
+/datum/supply_packs/vehicles/minigun_nest
+	name = "Mounted Minigun"
+	contains = list(/obj/structure/dropship_equipment/weapon_holder/minigun)
+	cost = 750
 
 /datum/supply_packs/vehicles/mounted_heavy_laser
 	name = "Mounted Heavy Laser"
-	contains = list(/obj/structure/dropship_equipment/heavylaser_holder)
+	contains = list(/obj/structure/dropship_equipment/weapon_holder/heavylaser)
 	cost = 900
 
 /datum/supply_packs/vehicles/mounted_rr
 	name = "Mounted Heavy Recoilless Rifle"
-	contains = list(/obj/structure/dropship_equipment/heavy_rr_holder)
+	contains = list(/obj/structure/dropship_equipment/weapon_holder/heavy_rr)
 	cost = 1800
 
 /datum/supply_packs/vehicles/hsg_ammo
 	name = "Mounted HSG ammo"
 	contains = list(/obj/item/ammo_magazine/tl102/hsg_nest)
 	cost = 100
+	containertype = /obj/structure/closet/crate/ammo
+
+/datum/supply_packs/vehicles/minigun_ammo
+	name = "Mounted Minigun ammo"
+	contains = list(/obj/item/ammo_magazine/heavy_minigun)
+	cost = 30
 	containertype = /obj/structure/closet/crate/ammo
 
 /datum/supply_packs/vehicles/hl_ammo


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Порт пра номер раз https://github.com/tgstation/TerraGov-Marine-Corps/pull/13411, номер двас https://github.com/tgstation/TerraGov-Marine-Corps/pull/13511 и номер трес https://github.com/tgstation/TerraGov-Marine-Corps/pull/13513.
Фикс от Блундира конечно тоже работал, правда только на базовый пулеметик, но у нас все равно другие пушки только Антис щупал.

## Why It's Good For The Game

Код стал лучше, пофиксилось несколько багов

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Readded the mounted nest minigun back to req
fix: Fixed mounted nest dropship equipment not letting you mount it
code: Refactored mounted nest dropship equipment to use inheritance
balance: Mounted guns have normalised bullet, laser and energy armor
balance: Mounted guns are dense when mounted again. Crushers rejoice
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
