### PR TITLE
Fix embedding

### DIFF
--- a/code/game/objects/items/embedding.dm
+++ b/code/game/objects/items/embedding.dm
@@ -82,6 +82,8 @@
 		stack_trace("limb_embed called for NODROP|DELONDROP [embedding]")
 		embedding.unembed_ourself()
 		return FALSE
+	if(embedding.w_class >= WEIGHT_CLASS_NORMAL)
+		return FALSE
 	if(limb_status & LIMB_DESTROYED)
 		return FALSE
 	if(!silent)
@@ -202,7 +204,7 @@
 	else
 		visible_message(span_warning("<b>[user] rips [selection] out of [src]'s body.</b>"),span_warning("<b>[user] rips [selection] out of your body.</b>"), null, 5)
 
-	handle_yank_out_damage()
+	handle_yank_out_damage(selection, user)
 
 	selection.unembed_ourself()
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -217,10 +217,6 @@ Contains most of the procs that are called when a mob is attacked by something
 	//Melee weapon embedded object code.
 	if(affecting.limb_status & LIMB_DESTROYED)
 		hit_report += "(delimbed [affecting.display_name])"
-	else if(I.damtype == BRUTE && !(I.flags_item & (NODROP|DELONDROP)))
-		if (percentage_penetration && weapon_sharp && prob(I.embedding.embed_chance))
-			I.embed_into(src, affecting)
-			hit_report += "(embedded in [affecting.display_name])"
 
 	log_combat(user, src, "attacked", I, "(INTENT: [uppertext(user.a_intent)]) (DAMTYE: [uppertext(I.damtype)]) [hit_report.Join(" ")]")
 	if(damage && !user.mind?.bypass_ff && !mind?.bypass_ff && user.faction == faction)


### PR DESCRIPTION
## About The Pull Request
пофикшены дюпы мили оружия
большие мили палки больше не будут застревать в бедных хуманах при бросках
пофикшен рантайм, появляющися после самостоятельного вытаскивания из своей жопы мили палок

## Why It's Good For The Game
100% предбаф
## Changelog

:cl:
fix: no dup mele weapon
fix: runtime\bug, proc dont have parametrs
add: check on w_class of mele weapon in embedding
/:cl:
