### PR TITLE
Tad/Crush-ship hagger trap fix

### DIFF
--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -6,6 +6,7 @@
 	var/xeno_structure_flags
 	///Which hive(number) do we belong to?
 	var/hivenumber = XENO_HIVE_NORMAL
+	var/decay_time = 1 SECONDS
 
 /obj/structure/xeno/Initialize(location, hivenumber)
 	. = ..()
@@ -45,6 +46,9 @@
 /// Destroy the xeno structure when the weed it was on is destroyed
 /obj/structure/xeno/proc/weed_removed()
 	SIGNAL_HANDLER
+	addtimer(CALLBACK(src, PROC_REF(structure_decay)), decay_time)
+
+/obj/structure/xeno/proc/structure_decay()
 	obj_destruction(damage_flag = "melee")
 
 /obj/structure/xeno/attack_alien(mob/living/carbon/xenomorph/X, damage_amount, damage_type, damage_flag, effects, armor_penetration, isrightclick)

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -69,6 +69,7 @@
 	anchored = TRUE
 	max_integrity = 5
 	layer = RESIN_STRUCTURE_LAYER
+	xeno_structure_flags = IGNORE_WEED_REMOVAL
 	destroy_sound = "alien_resin_break"
 	///defines for trap type to trigger on activation
 	var/trap_type
@@ -467,6 +468,7 @@ TUNNEL
 	opacity = FALSE
 	anchored = TRUE
 	max_integrity = 5
+	xeno_structure_flags = IGNORE_WEED_REMOVAL
 
 	hit_sound = "alien_resin_move"
 	destroy_sound = "alien_resin_move"
@@ -1169,7 +1171,7 @@ TUNNEL
 	bound_height = 64
 	obj_integrity = 600
 	max_integrity = 600
-	xeno_structure_flags = CRITICAL_STRUCTURE
+	xeno_structure_flags = IGNORE_WEED_REMOVAL | CRITICAL_STRUCTURE
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.25
 
@@ -1201,7 +1203,7 @@ TUNNEL
 	bound_height = 64
 	obj_integrity = 400
 	max_integrity = 400
-	xeno_structure_flags = CRITICAL_STRUCTURE
+	xeno_structure_flags = IGNORE_WEED_REMOVAL | CRITICAL_STRUCTURE
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.2
 

--- a/code/modules/xenomorph/xeno_structures.dm
+++ b/code/modules/xenomorph/xeno_structures.dm
@@ -69,7 +69,6 @@
 	anchored = TRUE
 	max_integrity = 5
 	layer = RESIN_STRUCTURE_LAYER
-	xeno_structure_flags = IGNORE_WEED_REMOVAL
 	destroy_sound = "alien_resin_break"
 	///defines for trap type to trigger on activation
 	var/trap_type
@@ -468,7 +467,6 @@ TUNNEL
 	opacity = FALSE
 	anchored = TRUE
 	max_integrity = 5
-	xeno_structure_flags = IGNORE_WEED_REMOVAL
 
 	hit_sound = "alien_resin_move"
 	destroy_sound = "alien_resin_move"
@@ -1171,7 +1169,7 @@ TUNNEL
 	bound_height = 64
 	obj_integrity = 600
 	max_integrity = 600
-	xeno_structure_flags = IGNORE_WEED_REMOVAL | CRITICAL_STRUCTURE
+	xeno_structure_flags = CRITICAL_STRUCTURE
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.25
 
@@ -1203,7 +1201,7 @@ TUNNEL
 	bound_height = 64
 	obj_integrity = 400
 	max_integrity = 400
-	xeno_structure_flags = IGNORE_WEED_REMOVAL | CRITICAL_STRUCTURE
+	xeno_structure_flags = CRITICAL_STRUCTURE
 	///boost amt to be added per tower per cycle
 	var/boost_amount = 0.2
 


### PR DESCRIPTION
## About The Pull Request
Теперь ловушки кэрьера, кислотные колодцы, и эво/матур таверы ломаются спустя секунду, после ломания травы под ними.
Из-за этого, ловушки/колодцы не срабатывают, когда на них приземляется ТАД/Корабль.
Увы.
