### PR TITLE
Fix: Leicester Repeater

### DIFF
--- a/code/modules/projectiles/guns/shotguns.dm
+++ b/code/modules/projectiles/guns/shotguns.dm
@@ -578,7 +578,7 @@
 	attachable_allowed = list(
 		/obj/item/attachable/reddot,
 		/obj/item/attachable/scope/mini,
-		/obj/item/attachable/scope,
+		/obj/item/attachable/scope/marine,
 		/obj/item/attachable/flashlight,
 		/obj/item/attachable/bayonet,
 		/obj/item/attachable/magnetic_harness,


### PR DESCRIPTION

## About The Pull Request

Изменил путь к прицелу с легаси на вполне существующий модуль в вендоре.

## Why It's Good For The Game

Это добавит более разнообразный геймплей для этого точно и мощного оружия. Если не будет хватать обзора, можно будет менять модуль во время передышек между боями.

## Changelog

:cl: 

fix: Now you can put a marine - T47 sight on the repeater

/:cl:


