### PR TITLE
[e] Leicester Repeater Tweak

### DIFF
--- a/code/modules/projectiles/ammo_datums.dm
+++ b/code/modules/projectiles/ammo_datums.dm
@@ -666,7 +666,7 @@ GLOBAL_LIST_INIT(no_sticky_resin, typecacheof(list(/obj/item/clothing/mask/faceh
 /datum/ammo/bullet/rifle/repeater
 	name = "heavy impact rifle bullet"
 	hud_state = "sniper"
-	damage = 70
+	damage = 65
 	penetration = 20
 	sundering = 1.25
 


### PR DESCRIPTION
## Changelog

**Leicester Repeater**
> Немного уменьшен урон в угоду эффекта замедления
-  [ _Ammo_ ] damage = **70 —> 65**
