### PR TITLE
прок Finish_lunge снова вернулся в строй у вориера

### DIFF
--- a/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
+++ b/code/modules/mob/living/carbon/xenomorph/castes/warrior/abilities_warrior.dm
@@ -128,7 +128,7 @@
 
 	RegisterSignal(lunge_target, COMSIG_PARENT_QDELETING, PROC_REF(clean_lunge_target))
 	RegisterSignal(X, COMSIG_MOVABLE_MOVED, PROC_REF(check_if_lunge_possible))
-	RegisterSignal(X, COMSIG_MOVABLE_POST_THROW, PROC_REF(clean_lunge_target))
+	RegisterSignal(X, COMSIG_MOVABLE_POST_THROW, PROC_REF(finish_lunge))
 	if(lunge_target.Adjacent(X)) //They're already in range, neck grab without lunging.
 		lunge_grab(X, lunge_target)
 	else


### PR DESCRIPTION
## About The Pull Request
сразу скажу, что это не фиксит баг, когда воин не может двигаться во время лунджа/граба

кто-то умный(или не очень) добавил прок finish_lunge(), заменив при этом в сигналлере "COMSIG_MOVABLE_POST_THROW" clean_lunge_target() на этот новый прок
следующий решил вернуть старый вызов прока, но оставив новый
а третий, решил убрать один из этих проков

чё делает этот прок? да не ебу

## Why It's Good For The Game
1%ксенобаф и 99%кодбаф

## Changelog

:cl:
fix: proc finish_lunge now use in warrior lunge
/:cl:

