### PR TITLE
2 disc nuke

### DIFF
--- a/code/game/objects/machinery/nuclearbomb.dm
+++ b/code/game/objects/machinery/nuclearbomb.dm
@@ -114,7 +114,7 @@
 			g_auth = I
 		if(/obj/item/disk/nuclear/blue)
 			b_auth = I
-	if(r_auth && g_auth && b_auth)
+	if((r_auth && g_auth && b_auth) || (r_auth && g_auth) || (r_auth && b_auth) || (g_auth && b_auth))
 		has_auth = TRUE
 
 	updateUsrDialog()
@@ -355,7 +355,7 @@
 				g_auth = I
 			if("blue")
 				b_auth = I
-		if(r_auth && g_auth && b_auth)
+		if((r_auth && g_auth && b_auth) || (r_auth && g_auth) || (r_auth && b_auth) || (g_auth && b_auth))
 			has_auth = TRUE
 
 ///Returns time left on the nuke


### PR DESCRIPTION
Теперь для запуска нюки на краше и нюке нужно два любых диска, вместо трёх