### PR TITLE
Extermination game mode

### DIFF
--- a/code/__DEFINES/mode.dm
+++ b/code/__DEFINES/mode.dm
@@ -50,6 +50,7 @@
 #define MODE_SILOS_SPAWN_MINIONS (1<<14)
 #define MODE_ALLOW_XENO_QUICKBUILD (1<<15)
 #define MODE_ALLOW_PINPOINTER (1<<16)
+#define MODE_SILO_NO_LARVA_GENERATION (1<<17)
 
 #define MODE_INFESTATION_X_MAJOR "Xenomorph Major Victory"
 #define MODE_INFESTATION_M_MAJOR "Marine Major Victory"

--- a/code/controllers/subsystem/silo.dm
+++ b/code/controllers/subsystem/silo.dm
@@ -42,5 +42,8 @@ SUBSYSTEM_DEF(silo)
 /datum/controller/subsystem/silo/proc/start_spawning()
 	SIGNAL_HANDLER
 	UnregisterSignal(SSdcs, list(COMSIG_GLOB_OPEN_TIMED_SHUTTERS_LATE, COMSIG_GLOB_OPEN_TIMED_SHUTTERS_XENO_HIVEMIND, COMSIG_GLOB_OPEN_SHUTTERS_EARLY, COMSIG_GLOB_TADPOLE_LAUNCHED))
+	if(SSticker.mode?.flags_round_type & MODE_SILO_NO_LARVA_GENERATION)
+		can_fire = FALSE
+		return
 	if(SSticker.mode?.flags_round_type & MODE_SILO_RESPAWN)
 		can_fire = TRUE

--- a/code/datums/gamemodes/extermination.dm
+++ b/code/datums/gamemodes/extermination.dm
@@ -5,7 +5,7 @@
 	flags_round_type = MODE_INFESTATION|MODE_LATE_OPENING_SHUTTER_TIMER|MODE_XENO_RULER|MODE_PSY_POINTS|MODE_PSY_POINTS_ADVANCED|MODE_DEAD_GRAB_FORBIDDEN|MODE_HIJACK_POSSIBLE|MODE_SILO_RESPAWN|MODE_SILOS_SPAWN_MINIONS|MODE_ALLOW_XENO_QUICKBUILD|MODE_ALLOW_PINPOINTER|MODE_SILO_NO_LARVA_GENERATION
 
 	///How long between two larva check, 2 minutes for crush
-	var/larva_check_interval = 1 MINUTES
+	var/larva_check_interval = 4 MINUTES
 	///Last time larva balance was checked
 	var/last_larva_check
 

--- a/code/datums/gamemodes/extermination.dm
+++ b/code/datums/gamemodes/extermination.dm
@@ -5,7 +5,7 @@
 	flags_round_type = MODE_INFESTATION|MODE_LATE_OPENING_SHUTTER_TIMER|MODE_XENO_RULER|MODE_PSY_POINTS|MODE_PSY_POINTS_ADVANCED|MODE_DEAD_GRAB_FORBIDDEN|MODE_HIJACK_POSSIBLE|MODE_SILO_RESPAWN|MODE_SILOS_SPAWN_MINIONS|MODE_ALLOW_XENO_QUICKBUILD|MODE_ALLOW_PINPOINTER|MODE_SILO_NO_LARVA_GENERATION
 
 	///How long between two larva check, 2 minutes for crush
-	var/larva_check_interval = 2 SECONDS
+	var/larva_check_interval = 1 MINUTES
 	///Last time larva balance was checked
 	var/last_larva_check
 
@@ -86,9 +86,9 @@
 		xeno_job.add_job_positions(1)
 		return
 	var/larva_surplus = (get_total_joblarvaworth() - (num_xenos * xeno_job.job_points_needed )) / xeno_job.job_points_needed
-	while(larva_surplus >= 1)
-		xeno_job.add_job_positions(1)
-		larva_surplus--
+	if(larva_surplus < 1)
+		return //Things are balanced, no burrowed needed
+	xeno_job.add_job_positions(1)
 	xeno_hive.update_tier_limits()
 
 

--- a/code/datums/gamemodes/extermination.dm
+++ b/code/datums/gamemodes/extermination.dm
@@ -1,0 +1,103 @@
+/datum/game_mode/infestation/distress/extermination
+	name = "Extermination"
+	config_tag = "Extermination"
+
+	flags_round_type = MODE_INFESTATION|MODE_LATE_OPENING_SHUTTER_TIMER|MODE_XENO_RULER|MODE_PSY_POINTS|MODE_PSY_POINTS_ADVANCED|MODE_DEAD_GRAB_FORBIDDEN|MODE_HIJACK_POSSIBLE|MODE_SILO_RESPAWN|MODE_SILOS_SPAWN_MINIONS|MODE_ALLOW_XENO_QUICKBUILD|MODE_ALLOW_PINPOINTER|MODE_SILO_NO_LARVA_GENERATION
+
+	///How long between two larva check, 2 minutes for crush
+	var/larva_check_interval = 2 SECONDS
+	///Last time larva balance was checked
+	var/last_larva_check
+
+/datum/game_mode/infestation/distress/extermination/post_setup()
+	. = ..()
+	for(var/i in GLOB.nuke_spawn_locs)
+		new /obj/machinery/nuclearbomb(i)
+	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_EXPLODED, PROC_REF(on_nuclear_explosion))
+	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_DIFFUSED, PROC_REF(on_nuclear_diffuse))
+	RegisterSignal(SSdcs, COMSIG_GLOB_NUKE_START, PROC_REF(on_nuke_started))
+
+/datum/game_mode/infestation/distress/extermination/check_finished()
+	if(round_finished)
+		return TRUE
+
+	if(world.time < (SSticker.round_start_time + 5 SECONDS))
+		return FALSE
+
+	var/list/living_player_list = count_humans_and_xenos(count_flags = COUNT_IGNORE_ALIVE_SSD|COUNT_IGNORE_XENO_SPECIAL_AREA)
+	var/num_humans = living_player_list[1]
+	var/num_xenos = living_player_list[2]
+	var/num_humans_ship = living_player_list[3]
+
+	if(SSevacuation.dest_status == NUKE_EXPLOSION_FINISHED)
+		message_admins("Round finished: [MODE_GENERIC_DRAW_NUKE]") //ship blows, no one wins
+		round_finished = MODE_GENERIC_DRAW_NUKE
+		return TRUE
+
+	if(round_stage == INFESTATION_DROPSHIP_CAPTURED_XENOS)
+		message_admins("Round finished: [MODE_INFESTATION_X_MINOR]")
+		round_finished = MODE_INFESTATION_X_MINOR
+		return TRUE
+
+	if(planet_nuked == INFESTATION_NUKE_COMPLETED)
+		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines managed to nuke the colony
+		round_finished = MODE_INFESTATION_M_MAJOR
+		return TRUE
+
+	if(!num_humans)
+		if(!num_xenos)
+			message_admins("Round finished: [MODE_INFESTATION_DRAW_DEATH]") //everyone died at the same time, no one wins
+			round_finished = MODE_INFESTATION_DRAW_DEATH
+			return TRUE
+		message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]") //xenos wiped out ALL the marines without hijacking, xeno major victory
+		round_finished = MODE_INFESTATION_X_MAJOR
+		return TRUE
+	if(!num_xenos)
+		if(round_stage == INFESTATION_MARINE_CRASHING)
+			message_admins("Round finished: [MODE_INFESTATION_M_MINOR]") //marines lost the ground operation but managed to wipe out Xenos on the ship at a greater cost, minor victory
+			round_finished = MODE_INFESTATION_M_MINOR
+			return TRUE
+		message_admins("Round finished: [MODE_INFESTATION_M_MAJOR]") //marines win big
+		round_finished = MODE_INFESTATION_M_MAJOR
+		return TRUE
+	if(round_stage == INFESTATION_MARINE_CRASHING && !num_humans_ship)
+		if(SSevacuation.human_escaped > SSevacuation.initial_human_on_ship * 0.5)
+			message_admins("Round finished: [MODE_INFESTATION_X_MINOR]") //xenos have control of the ship, but most marines managed to flee
+			round_finished = MODE_INFESTATION_X_MINOR
+			return
+		message_admins("Round finished: [MODE_INFESTATION_X_MAJOR]") //xenos wiped our marines, xeno major victory
+		round_finished = MODE_INFESTATION_X_MAJOR
+		return TRUE
+	return FALSE
+
+/datum/game_mode/infestation/distress/extermination/process()
+	. = ..()
+
+	if(world.time > last_larva_check + larva_check_interval)
+		balance_scales()
+		last_larva_check = world.time
+
+/datum/game_mode/infestation/distress/extermination/proc/balance_scales()
+	var/datum/hive_status/normal/xeno_hive = GLOB.hive_datums[XENO_HIVE_NORMAL]
+	var/datum/job/xeno_job = SSjob.GetJobType(/datum/job/xenomorph)
+	var/stored_larva = xeno_job.total_positions - xeno_job.current_positions
+	var/num_xenos = xeno_hive.get_total_xeno_number() + stored_larva
+	if(!num_xenos)
+		xeno_job.add_job_positions(1)
+		return
+	var/larva_surplus = (get_total_joblarvaworth() - (num_xenos * xeno_job.job_points_needed )) / xeno_job.job_points_needed
+	while(larva_surplus >= 1)
+		xeno_job.add_job_positions(1)
+		larva_surplus--
+	xeno_hive.update_tier_limits()
+
+
+/datum/game_mode/infestation/distress/extermination/get_total_joblarvaworth(list/z_levels, count_flags)
+	. = 0
+
+	for(var/mob/living/carbon/human/H AS in GLOB.human_mob_list)
+		if(!H.job)
+			continue
+		if(isspaceturf(H.loc))
+			continue
+		. += H.job.jobworth[/datum/job/xenomorph]

--- a/tgmc.dme
+++ b/tgmc.dme
@@ -424,6 +424,7 @@
 #include "code\datums\gamemodes\extended.dm"
 #include "code\datums\gamemodes\infestation.dm"
 #include "code\datums\gamemodes\nuclear_war.dm"
+#include "code\datums\gamemodes\extermination.dm"
 #include "code\datums\gamemodes\objective.dm"
 #include "code\datums\gamemodes\objective_items.dm"
 #include "code\datums\gamemodes\sensor_capture.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Добавляет новый режим Extermination (очень пафосное название).
Основные отличия:
Марины имеют 2 способа победить: уничтожить сило, взорвать нюку.
Респавн ксен сделан на манер краша

## Why It's Good For The Game

Для начала расскажу что не так по моему мнению с другими режимами (нюкой и дистрессом) и какие проблемы я постарался решить.
Большинсто раундов можно чётко разделить на два случая: марины успешно унганули и вынесли половину ксенов вместе с сило (короткий раунд на стороне маринов), либо ксены успешно держат оборону до сила, диска с минимальными потерями и имеют необычайное количество лявр от генерации сила (долгий раунд на стороне ксеносов). В первом случае марины или ксены просто тянут время на уже обречённый раунд гоняясь за единственным шреком, ставящим сило то в одной, то в другой части карты; во втором маринам становится просто невозможно по истечению определённого времени хоть как то победить, соотношение ксен к марам становится просто абсурдным (особенно если учитывать трупы). Каждый раунд хрупкий баланс перетекает то в одну сторону, то в другую сторону, делая игру скучной для одной из сторон, и просто невыносимой для второй.
И так начнём с первой проблемы: соотношение ксен/марин, лявра скейлинг и т.д.. В первую очередь это возникает из-за механики самого сила, которое может хоть медленно (а может и нет, спасибо лявраскейлингу), но плодить лявр ДО БЕСКОНЕЧНОСТИ, но в то же время не может восстановить популяцию до приемлемых значений после крупных потерь, делая дальнейшую игру практически бессмысленной. В какой то мере это очень хрупкие качели, которые могут перевеситься в одну сторону из за неудачной атаки, ошибки, но уже с большим трудом уравновеситься.
Не очень элегантное, но просто решение - поддерживать определённый статический баланс между двумя сторонами, как это сделано на краше. Конечно тогда возникает другой вопрос - сделает ли это смерть ксеноморфа бессмысленной? В любом случае смерть ксеноса будет менее значимой, но не бессмысленной, ведь: 1) ксеноморфу придётся ждать роста, взросления, делая его уязвимым в это время 2) труп можно продать (ура крутые пушки и броня). И да, марам будет не достаточно просто убивать ксен чтобы победить, что уже затрагивает вторую проблему.
Вторая проблема - тактика, или куда понятнее - унгаболл. Самая простая, понятная, а самое главное ЭФФЕКТИВНАЯ тактика, выходящая из сущности самого режима дистресса и вещей сказанных выше про генерацию сило.  Если для дистресса блицкриг от ЛЗ до сила кажется весьма понятным, это цель режима, то с вопросом нюки дела обстоят посложнее. Допустим марины в количестве 30 решили делать диски и для занятия и печати диска потребуется 10 минут (путь к диску, укрепление, и т.д.), ксен же будет 12 (соотношение 1/2.5). По истечении 30 минут сило + псидрейны с коконами сделают + 7 - 8 лявр(а то и более) и тогда соотношение будет 1/1.5,при условии что ксены не умирали (за гранью невозможного) это не учитывая что за это время некоторые мары уже могли умереть. С таким соотношением уже будет сложно дойти до самой нюки. С другой же стороны за те же 30 минут опытные мары могут истребить и 10 и более ксенов, что сделает дальнейшую игру просто скучной, ведь на дистрессе это можно было бы уже просто закончить, но на нюке приходится делать диски и тянуть время. Вот и получается, что НЕ уничтожать сило не имеет смысла, ведь игнорируя его вы обрекаете себя сложный лейт гейм, либо в любом случае без проблем уничтожаете беносов, поэтому отсутствие сило колапса на нюке бессмысленно, отсутствие сило уже означает проигрыш  для ксеноморфов (не учитывая скилл ишуй маров).
Третья менее очевидная проблема - время, опять же вытекает из всего вышесказанного. Если раунд короткий то карго не нужно (и так побеждаем), медики простаивают без дела (кто то умер? ), инженеры напоминают обычных маров (какие кады? оборона? все уже убежали пить чай), Если раунд действительно длинный (а не искусственно затянутый), то тогда ксены начинают давить, слишком сильно нагружая всех и в конечном счёте проламывают все кады и идут за оставшимися врачами по трупам, а РО грустно смотрит на 2000 очков в карго и готовит эвак.
Ну и по поему мнению изменения внесённые в данный режим должны частично решить все эти проблемы, или по крайней мере постараться решить:
1) соотношение сторон - респавн краша, постоянный баланс
2) тактика - марины имею 2 способа для победы (ксеносам ещё придётся обращать внимание как на диски так и на сило)
3) время - раунды должны быть более продолжительными чтобы включить в себя все возможности игры и максимум механик, особенностей ролей.


## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Added extermination game mode
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
