### PR TITLE
Changes places of guns with mags in the holsters so you can take it out quickly.

### DIFF
--- a/code/modules/clothing/modular_armor/attachments/uniform.dm
+++ b/code/modules/clothing/modular_armor/attachments/uniform.dm
@@ -119,24 +119,24 @@
 
 /obj/item/armor_module/storage/uniform/holster/freelancer/Initialize()
 	. = ..()
+	new /obj/item/ammo_magazine/pistol/g22(storage)
+	new /obj/item/ammo_magazine/pistol/g22(storage)
+	new /obj/item/ammo_magazine/pistol/g22(storage)
 	new /obj/item/weapon/gun/pistol/g22(storage)
-	new /obj/item/ammo_magazine/pistol/g22(storage)
-	new /obj/item/ammo_magazine/pistol/g22(storage)
-	new /obj/item/ammo_magazine/pistol/g22(storage)
 
 /obj/item/armor_module/storage/uniform/holster/vp/Initialize()
 	. = ..()
+	new /obj/item/ammo_magazine/pistol/vp70(storage)
+	new /obj/item/ammo_magazine/pistol/vp70(storage)
+	new /obj/item/ammo_magazine/pistol/vp70(storage)
 	new /obj/item/weapon/gun/pistol/vp70(storage)
-	new /obj/item/ammo_magazine/pistol/vp70(storage)
-	new /obj/item/ammo_magazine/pistol/vp70(storage)
-	new /obj/item/ammo_magazine/pistol/vp70(storage)
 
 /obj/item/armor_module/storage/uniform/holster/highpower/Initialize()
 	. = ..()
+	new /obj/item/ammo_magazine/pistol/highpower(storage)
+	new /obj/item/ammo_magazine/pistol/highpower(storage)
+	new /obj/item/ammo_magazine/pistol/highpower(storage)
 	new /obj/item/weapon/gun/pistol/highpower(storage)
-	new /obj/item/ammo_magazine/pistol/highpower(storage)
-	new /obj/item/ammo_magazine/pistol/highpower(storage)
-	new /obj/item/ammo_magazine/pistol/highpower(storage)
 
 /obj/item/storage/internal/holster
 	storage_slots = 4


### PR DESCRIPTION
Пистолеты теперь будут в первых слотах холстера вместо магазинов, потому что ты так или иначе либо заранее оставишь пистолет в первом слоте либо достанешь бесполезный магазин посреди боя.